### PR TITLE
Fix tsconfig to exclude cpp_native from type checking

### DIFF
--- a/elevate/tsconfig.json
+++ b/elevate/tsconfig.json
@@ -12,5 +12,9 @@
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
-	}
+	},
+	"exclude": [
+		"cpp_native",
+		"node_modules"
+	]
 }


### PR DESCRIPTION
## Summary
- Adds `exclude` to `tsconfig.json` to ignore `cpp_native` and `node_modules`
- CMake build artifacts in `cpp_native` have `.ts` file extensions which caused `tsc` to pick them up and report invalid character errors

## Test plan
- [ ] Run `npm run compile` and verify no `cpp_native` errors