### PR TITLE
fix: cross-platform test runner (xvfb on Linux, native on macOS)

### DIFF
--- a/elevate/package.json
+++ b/elevate/package.json
@@ -114,7 +114,7 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
-    "test": "vscode-test",
+    "test": "xvfb-run -a vscode-test",
     "postinstall": "node scripts/ollama-ensure-model.mjs",
     "setup:ollama": "node scripts/ollama-ensure-model.mjs",
     "prepare": "git config core.hooksPath .husky"

--- a/elevate/package.json
+++ b/elevate/package.json
@@ -114,7 +114,7 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
-    "test": "xvfb-run -a vscode-test",
+    "test": "node scripts/test.mjs",
     "postinstall": "node scripts/ollama-ensure-model.mjs",
     "setup:ollama": "node scripts/ollama-ensure-model.mjs",
     "prepare": "git config core.hooksPath .husky"

--- a/elevate/scripts/test.mjs
+++ b/elevate/scripts/test.mjs
@@ -1,0 +1,7 @@
+import { execSync } from 'child_process';
+
+// On Linux (WSL2/CI) a virtual display is required to run the VSCode test host.
+// xvfb-run provides one. On macOS a display is already available so we skip it.
+const cmd = process.platform === 'linux' ? 'xvfb-run -a vscode-test' : 'vscode-test';
+
+execSync(cmd, { stdio: 'inherit' });

--- a/elevate/src/test/extension.test.ts
+++ b/elevate/src/test/extension.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
 import { access } from 'fs/promises';
 import { ElevateContext } from '../backend/ElevateContext';
 import { CoreStateManager } from '../backend/CoreStateManager';
@@ -11,6 +13,8 @@ import { OllamaClient } from '../backend/OllamaClient';
 import { JobQueue } from '../backend/JobQueue';
 import { JobStatus, JobRecord } from '../backend/types';
 import { SseHub } from '../backend/SSEHub';
+import { ExtensionController, AnalysisResult } from '../extension/ExtensionController';
+import { ElevateCore } from '../backend/ElevateCore';
 
 suite('ElevateContext', () => {
     test('constructs from text string', () => {
@@ -97,13 +101,10 @@ suite('Pipeline', () => {
         assert.deepStrictEqual(ran, ['good']);
     });
 
-    test('runs without throwing on stubbed stages', async () => {
+    test('runs without throwing on SanitizationStage alone', async () => {
         const ctx = new ElevateContext('test context');
         const logger = new Logger('test', false);
-        const pipeline = new Pipeline(
-            [new SanitizationStage(), new PromptBuilderStage()],
-            logger
-        );
+        const pipeline = new Pipeline([new SanitizationStage()], logger);
         await assert.doesNotReject(() => pipeline.execute(ctx));
     });
 });
@@ -221,6 +222,37 @@ suite('ParseStage (integration)', () => {
         await stage.run(ctx);
         assert.ok(Array.isArray(ctx.parsed), 'ctx.parsed should be an array');
         assert.ok(ctx.parsed!.length > 0, 'ctx.parsed should contain at least one event');
+    });
+});
+
+suite('PromptBuilderStage (integration)', () => {
+    const promptBuilderBin = path.resolve(__dirname, '../../cpp_native/build/bin/prompt_builder');
+
+    test('throws when ctx.parsed is not set', async () => {
+        const stage = new PromptBuilderStage(promptBuilderBin);
+        const ctx = new ElevateContext('def foo(): pass');
+        await assert.rejects(() => stage.run(ctx), /ctx.parsed is not set/);
+    });
+
+    test('populates ctx.prompt from real parser output', async () => {
+        try {
+            await access(promptBuilderBin);
+        } catch {
+            console.log('PromptBuilderStage test skipped: binary not found');
+            return;
+        }
+
+        const parserBin = path.resolve(__dirname, '../../cpp_native/build/bin/parser');
+        const parseStage = new ParseStage(parserBin);
+        const promptStage = new PromptBuilderStage(promptBuilderBin);
+
+        const ctx = new ElevateContext('def add(a, b):\n    return a + b\n');
+        await parseStage.run(ctx);
+        await promptStage.run(ctx);
+
+        assert.ok(Array.isArray(ctx.prompt) && ctx.prompt.length > 0, 'ctx.prompt should be set');
+        assert.ok(ctx.prompt![0].content.length > 0, 'prompt content should not be empty');
+        assert.ok(ctx.prompt![0].content.includes('Role:'), 'prompt should include Role section from prompt_builder');
     });
 });
 

--- a/elevate/src/test/extension.test.ts
+++ b/elevate/src/test/extension.test.ts
@@ -1,8 +1,6 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as os from 'os';
-import * as fs from 'fs';
 import { access } from 'fs/promises';
 import { ElevateContext } from '../backend/ElevateContext';
 import { CoreStateManager } from '../backend/CoreStateManager';
@@ -13,8 +11,6 @@ import { OllamaClient } from '../backend/OllamaClient';
 import { JobQueue } from '../backend/JobQueue';
 import { JobStatus, JobRecord } from '../backend/types';
 import { SseHub } from '../backend/SSEHub';
-import { ExtensionController, AnalysisResult } from '../extension/ExtensionController';
-import { ElevateCore } from '../backend/ElevateCore';
 
 suite('ElevateContext', () => {
     test('constructs from text string', () => {
@@ -101,10 +97,13 @@ suite('Pipeline', () => {
         assert.deepStrictEqual(ran, ['good']);
     });
 
-    test('runs without throwing on SanitizationStage alone', async () => {
+    test('runs without throwing on stubbed stages', async () => {
         const ctx = new ElevateContext('test context');
         const logger = new Logger('test', false);
-        const pipeline = new Pipeline([new SanitizationStage()], logger);
+        const pipeline = new Pipeline(
+            [new SanitizationStage(), new PromptBuilderStage()],
+            logger
+        );
         await assert.doesNotReject(() => pipeline.execute(ctx));
     });
 });
@@ -222,37 +221,6 @@ suite('ParseStage (integration)', () => {
         await stage.run(ctx);
         assert.ok(Array.isArray(ctx.parsed), 'ctx.parsed should be an array');
         assert.ok(ctx.parsed!.length > 0, 'ctx.parsed should contain at least one event');
-    });
-});
-
-suite('PromptBuilderStage (integration)', () => {
-    const promptBuilderBin = path.resolve(__dirname, '../../cpp_native/build/bin/prompt_builder');
-
-    test('throws when ctx.parsed is not set', async () => {
-        const stage = new PromptBuilderStage(promptBuilderBin);
-        const ctx = new ElevateContext('def foo(): pass');
-        await assert.rejects(() => stage.run(ctx), /ctx.parsed is not set/);
-    });
-
-    test('populates ctx.prompt from real parser output', async () => {
-        try {
-            await access(promptBuilderBin);
-        } catch {
-            console.log('PromptBuilderStage test skipped: binary not found');
-            return;
-        }
-
-        const parserBin = path.resolve(__dirname, '../../cpp_native/build/bin/parser');
-        const parseStage = new ParseStage(parserBin);
-        const promptStage = new PromptBuilderStage(promptBuilderBin);
-
-        const ctx = new ElevateContext('def add(a, b):\n    return a + b\n');
-        await parseStage.run(ctx);
-        await promptStage.run(ctx);
-
-        assert.ok(Array.isArray(ctx.prompt) && ctx.prompt.length > 0, 'ctx.prompt should be set');
-        assert.ok(ctx.prompt![0].content.length > 0, 'prompt content should not be empty');
-        assert.ok(ctx.prompt![0].content.includes('Role:'), 'prompt should include Role section from prompt_builder');
     });
 });
 


### PR DESCRIPTION
## Summary
- Adds `scripts/test.mjs` that wraps `vscode-test` with `xvfb-run -a` on Linux (WSL2/CI) and runs it directly on macOS where a display is already available
- Updates `package.json` test script to use the new script

## Merge order
Merge this first — the other two PRs depend on the test runner working.

## Test plan
- [ ] `npm test` passes on Linux/WSL2
- [ ] `npm test` passes on macOS (no xvfb needed)