### PR TITLE
fix: stop pipeline feedback loop and add stage-level logging

### DIFF
--- a/elevate/src/Logger.ts
+++ b/elevate/src/Logger.ts
@@ -81,7 +81,7 @@ export class Logger implements vscode.Disposable {
     // Log the entire repsonse from LLM
     logResponseFinal(response: string) {
         const trimmed = this.truncate(response);
-        this.info("Final response from Ollama:\n" + trimmed)
+        this.info("Final response from Ollama:\n" + trimmed);
     }
 
     show() {

--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -36,10 +36,11 @@ export class ElevateCore {
     this.queue = new JobQueue(this.store, this.hub, this.ollama, { concurrency });
 
     const parserBin = path.join(context.extensionUri.fsPath, "cpp_native", "build", "bin", "parser");
+    const promptBuilderBin = path.join(context.extensionUri.fsPath, "cpp_native", "build", "bin", "prompt_builder");
 
     this.logger = new Logger(output);
     this.pipeline = new Pipeline(
-      [new SanitizationStage(), new ParseStage(parserBin), new PromptBuilderStage(), new OllamaStage(this.ollama)],
+      [new SanitizationStage(), new ParseStage(parserBin), new PromptBuilderStage(promptBuilderBin), new OllamaStage(this.ollama)],
       this.logger
     );
   }

--- a/elevate/src/editListener.ts
+++ b/elevate/src/editListener.ts
@@ -55,6 +55,7 @@ export class EditListener implements vscode.Disposable {
   private onTextDocumentChanged(e: vscode.TextDocumentChangeEvent): void {
     // Filter non-content changes (dirty state flips etc.)
     if (e.contentChanges.length === 0) return;
+    if (e.document.uri.scheme !== 'file') return;
 
     const key = e.document.uri.toString();
     const gen = (this.generation.get(key) ?? 0) + 1;
@@ -64,6 +65,7 @@ export class EditListener implements vscode.Disposable {
   }
 
   private onTextDocumentSaved(doc: vscode.TextDocument): void {
+    if (doc.uri.scheme !== 'file') return;
     const key = doc.uri.toString();
 
     // Cancel any pending debounced edit — the save fires onEdit directly below

--- a/elevate/src/extension.ts
+++ b/elevate/src/extension.ts
@@ -60,6 +60,7 @@ export async function activate(context: vscode.ExtensionContext) {
     fsWatcherGlob,
     onEdit: (doc) => {
       if (!backend) { return; }
+      if (doc.uri.scheme !== 'file') { return; }
       const ctx = new ElevateContext(doc);
       backend.runPipeline(ctx).catch((err) =>
         output.appendLine(`[ELEVATE] Pipeline error: ${err?.message ?? String(err)}`)

--- a/elevate/src/extension/ExtensionController.ts
+++ b/elevate/src/extension/ExtensionController.ts
@@ -12,6 +12,7 @@ export class ExtensionController {
     public activateOpenFileListener(context: vscode.ExtensionContext): void {
         const openFileListener = vscode.workspace.onDidOpenTextDocument(
             async (document: vscode.TextDocument) => {
+                this.logger.info(`[open-file] fired: scheme=${document.uri.scheme} uri=${document.uri.toString()}`);
                 if (document.uri.scheme !== 'file') return;
 
                 const ctx = new ElevateContext(document);

--- a/elevate/src/pipeline/Pipeline.ts
+++ b/elevate/src/pipeline/Pipeline.ts
@@ -19,7 +19,7 @@ export class Pipeline {
             
             try {
                 this.logger.info(`Running stage: ${stage.name}`);
-                await stage.run(ctx);
+                await stage.run(ctx, this.logger);
                 this.logger.info(`Completed stage: ${stage.name}`);
             } catch (error) {
 

--- a/elevate/src/pipeline/Stage.ts
+++ b/elevate/src/pipeline/Stage.ts
@@ -6,15 +6,16 @@ import { writeFile, readFile, unlink } from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { OllamaClient } from "../backend/OllamaClient";
+import { Logger } from "../Logger";
 
 export interface Stage {
     name: string;
-    run(ctx: ElevateContext): Promise<void>;
+    run(ctx: ElevateContext, logger: Logger): Promise<void>;
 }
 
 export class SanitizationStage implements Stage {
     name = "Sanitization Stage";
-    async run(ctx: ElevateContext): Promise<void> {
+    async run(_ctx: ElevateContext, _logger: Logger): Promise<void> {
 
     }
 }
@@ -24,11 +25,13 @@ export class ParseStage implements Stage {
 
     constructor(private readonly binPath: string) {}
 
-    async run(ctx: ElevateContext): Promise<void> {
+    async run(ctx: ElevateContext, logger: Logger): Promise<void> {
         const code = ctx.analysisTarget ?? ctx.snapshot?.text ?? ctx.text;
         if (!code) {
             throw new Error("ParseStage: no code to parse");
         }
+
+        logger.debug(`ParseStage: parsing ${code.length} chars`);
 
         const inputPath = path.join(os.tmpdir(), `elevate_in_${Date.now()}.py`);
         const outputPath = path.join(os.tmpdir(), `elevate_out_${Date.now()}.json`);
@@ -52,6 +55,8 @@ export class ParseStage implements Stage {
         const raw = await readFile(outputPath, "utf-8");
         ctx.parsed = JSON.parse(raw) as BlockEvent[];
 
+        logger.debug(`ParseStage: produced ${ctx.parsed.length} block event(s)`);
+
         await unlink(inputPath).catch(() => {});
         await unlink(outputPath).catch(() => {});
     }
@@ -62,15 +67,16 @@ export class PromptBuilderStage implements Stage {
 
     constructor(private readonly binPath: string) {}
 
-    async run(ctx: ElevateContext): Promise<void> {
+    async run(ctx: ElevateContext, logger: Logger): Promise<void> {
         if (!ctx.parsed) {
             throw new Error("PromptBuilderStage: ctx.parsed is not set — ParseStage must run first");
         }
 
+        logger.debug(`PromptBuilderStage: building prompt from ${ctx.parsed.length} block event(s)`);
+
         const inputPath = path.join(os.tmpdir(), `elevate_prompt_in_${Date.now()}.json`);
         const outputPath = path.join(os.tmpdir(), `elevate_prompt_out_${Date.now()}.txt`);
 
-        // Write the parser JSON output to a temp file for the binary to read
         await writeFile(inputPath, JSON.stringify(ctx.parsed), "utf-8");
 
         await new Promise<void>((resolve, reject) => {
@@ -91,6 +97,8 @@ export class PromptBuilderStage implements Stage {
 
         ctx.prompt = [{ role: "user", content: promptText }];
 
+        logger.logPrompt(promptText);
+
         await unlink(inputPath).catch(() => {});
         await unlink(outputPath).catch(() => {});
     }
@@ -101,7 +109,7 @@ export class OllamaStage implements Stage {
 
     constructor(private readonly client: OllamaClient) {}
 
-    async run(ctx: ElevateContext): Promise<void> {
+    async run(ctx: ElevateContext, logger: Logger): Promise<void> {
         /*
          * Requires ctx.prompt to be populated by PromptBuilderStage.
          * Reads the target model from VSCode settings (elevate.defaultModel),
@@ -117,6 +125,8 @@ export class OllamaStage implements Stage {
             .getConfiguration("elevate")
             .get<string>("defaultModel") ?? "llama3.2:3b";
 
+        logger.info(`OllamaStage: sending prompt to model "${model}"`);
+
         const abort = new AbortController();
         let response = "";
 
@@ -129,6 +139,8 @@ export class OllamaStage implements Stage {
                 response += chunk.delta;
             }
         }
+
+        logger.logResponseFinal(response);
 
         ctx.modelResponse = response;
     }

--- a/elevate/src/pipeline/Stage.ts
+++ b/elevate/src/pipeline/Stage.ts
@@ -59,8 +59,40 @@ export class ParseStage implements Stage {
 
 export class PromptBuilderStage implements Stage {
     name = "Prompt Builder Stage";
-    async run(ctx: ElevateContext): Promise<void> {
 
+    constructor(private readonly binPath: string) {}
+
+    async run(ctx: ElevateContext): Promise<void> {
+        if (!ctx.parsed) {
+            throw new Error("PromptBuilderStage: ctx.parsed is not set — ParseStage must run first");
+        }
+
+        const inputPath = path.join(os.tmpdir(), `elevate_prompt_in_${Date.now()}.json`);
+        const outputPath = path.join(os.tmpdir(), `elevate_prompt_out_${Date.now()}.txt`);
+
+        // Write the parser JSON output to a temp file for the binary to read
+        await writeFile(inputPath, JSON.stringify(ctx.parsed), "utf-8");
+
+        await new Promise<void>((resolve, reject) => {
+            const proc = spawn(this.binPath, [inputPath, outputPath]);
+            let stderr = "";
+            proc.stderr.on("data", (d) => (stderr += d.toString()));
+            proc.on("close", (code) => {
+                if (code !== 0) {
+                    reject(new Error(`PromptBuilder exited with code ${code}: ${stderr}`));
+                } else {
+                    resolve();
+                }
+            });
+            proc.on("error", reject);
+        });
+
+        const promptText = await readFile(outputPath, "utf-8");
+
+        ctx.prompt = [{ role: "user", content: promptText }];
+
+        await unlink(inputPath).catch(() => {});
+        await unlink(outputPath).catch(() => {});
     }
 }
 

--- a/elevate/src/test/extension.test.ts
+++ b/elevate/src/test/extension.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
 import { access } from 'fs/promises';
 import { ElevateContext } from '../backend/ElevateContext';
 import { CoreStateManager } from '../backend/CoreStateManager';
@@ -97,13 +99,10 @@ suite('Pipeline', () => {
         assert.deepStrictEqual(ran, ['good']);
     });
 
-    test('runs without throwing on stubbed stages', async () => {
+    test('runs without throwing on SanitizationStage alone', async () => {
         const ctx = new ElevateContext('test context');
         const logger = new Logger('test', false);
-        const pipeline = new Pipeline(
-            [new SanitizationStage(), new PromptBuilderStage()],
-            logger
-        );
+        const pipeline = new Pipeline([new SanitizationStage()], logger);
         await assert.doesNotReject(() => pipeline.execute(ctx));
     });
 });
@@ -221,6 +220,33 @@ suite('ParseStage (integration)', () => {
         await stage.run(ctx);
         assert.ok(Array.isArray(ctx.parsed), 'ctx.parsed should be an array');
         assert.ok(ctx.parsed!.length > 0, 'ctx.parsed should contain at least one event');
+    });
+});
+
+suite('PromptBuilderStage (integration)', () => {
+    const promptBuilderBin = path.resolve(__dirname, '../../cpp_native/build/bin/prompt_builder');
+    const parserBin = path.resolve(__dirname, '../../cpp_native/build/bin/parser');
+
+    test('throws when ctx.parsed is not set', async () => {
+        const stage = new PromptBuilderStage(promptBuilderBin);
+        const ctx = new ElevateContext('def foo(): pass');
+        await assert.rejects(() => stage.run(ctx), /ctx.parsed is not set/);
+    });
+
+    test('populates ctx.prompt from real parser output', async () => {
+        try {
+            await access(promptBuilderBin);
+        } catch {
+            console.log('PromptBuilderStage test skipped: binary not found');
+            return;
+        }
+
+        const ctx = new ElevateContext('def add(a, b):\n    return a + b\n');
+        await new ParseStage(parserBin).run(ctx);
+        await new PromptBuilderStage(promptBuilderBin).run(ctx);
+
+        assert.ok(Array.isArray(ctx.prompt) && ctx.prompt!.length > 0, 'ctx.prompt should be set');
+        assert.ok(ctx.prompt![0].content.includes('Role:'), 'prompt should include Role section from prompt_builder');
     });
 });
 

--- a/elevate/src/test/extension.test.ts
+++ b/elevate/src/test/extension.test.ts
@@ -73,7 +73,7 @@ suite('Pipeline', () => {
 
         const makeStage = (n: number): Stage => ({
             name: `stage-${n}`,
-            run: async (_ctx) => { order.push(n); }
+            run: async (_ctx, _logger) => { order.push(n); }
         });
 
         const logger = new Logger('test', false);
@@ -87,9 +87,9 @@ suite('Pipeline', () => {
     test('stops execution and throws when a stage fails', async () => {
         const ran: string[] = [];
 
-        const good: Stage = { name: 'good', run: async () => { ran.push('good'); } };
-        const bad: Stage = { name: 'bad', run: async () => { throw new Error('stage failed'); } };
-        const after: Stage = { name: 'after', run: async () => { ran.push('after'); } };
+        const good: Stage = { name: 'good', run: async (_ctx, _logger) => { ran.push('good'); } };
+        const bad: Stage = { name: 'bad', run: async (_ctx, _logger) => { throw new Error('stage failed'); } };
+        const after: Stage = { name: 'after', run: async (_ctx, _logger) => { ran.push('after'); } };
 
         const logger = new Logger('test', false);
         const pipeline = new Pipeline([good, bad, after], logger);
@@ -163,11 +163,13 @@ suite('OllamaClient', () => {
 });
 
 suite('OllamaStage', () => {
+    const logger = new Logger('test', false);
+
     test('throws when ctx.prompt is not set', async () => {
         const mockClient = { chatStream: async function* () {} } as any as OllamaClient;
         const stage = new OllamaStage(mockClient);
         const ctx = new ElevateContext('test');
-        await assert.rejects(() => stage.run(ctx), /OllamaStage: no prompt set on context/);
+        await assert.rejects(() => stage.run(ctx, logger), /OllamaStage: no prompt set on context/);
     });
 
     test('throws when ctx.prompt is an empty array', async () => {
@@ -175,7 +177,7 @@ suite('OllamaStage', () => {
         const stage = new OllamaStage(mockClient);
         const ctx = new ElevateContext('test');
         ctx.prompt = [];
-        await assert.rejects(() => stage.run(ctx), /OllamaStage: no prompt set on context/);
+        await assert.rejects(() => stage.run(ctx, logger), /OllamaStage: no prompt set on context/);
     });
 
     test('accumulates chunk deltas into ctx.modelResponse', async () => {
@@ -188,7 +190,7 @@ suite('OllamaStage', () => {
         const stage = new OllamaStage(mockClient);
         const ctx = new ElevateContext('test');
         ctx.prompt = [{ role: 'user', content: 'analyze this' }];
-        await stage.run(ctx);
+        await stage.run(ctx, logger);
         assert.strictEqual(ctx.modelResponse, 'Hello world');
     });
 
@@ -201,12 +203,14 @@ suite('OllamaStage', () => {
         const stage = new OllamaStage(mockClient);
         const ctx = new ElevateContext('test');
         ctx.prompt = [{ role: 'user', content: 'hi' }];
-        await stage.run(ctx);
+        await stage.run(ctx, logger);
         assert.strictEqual(ctx.modelResponse, '');
     });
 });
 
 suite('ParseStage (integration)', () => {
+    const logger = new Logger('test', false);
+
     test('parses a minimal Python function and populates ctx.parsed', async () => {
         const parserBin = path.resolve(__dirname, '../../cpp_native/build/bin/parser');
         try {
@@ -217,20 +221,21 @@ suite('ParseStage (integration)', () => {
         }
         const stage = new ParseStage(parserBin);
         const ctx = new ElevateContext('def foo():\n    pass\n');
-        await stage.run(ctx);
+        await stage.run(ctx, logger);
         assert.ok(Array.isArray(ctx.parsed), 'ctx.parsed should be an array');
         assert.ok(ctx.parsed!.length > 0, 'ctx.parsed should contain at least one event');
     });
 });
 
 suite('PromptBuilderStage (integration)', () => {
+    const logger = new Logger('test', false);
     const promptBuilderBin = path.resolve(__dirname, '../../cpp_native/build/bin/prompt_builder');
     const parserBin = path.resolve(__dirname, '../../cpp_native/build/bin/parser');
 
     test('throws when ctx.parsed is not set', async () => {
         const stage = new PromptBuilderStage(promptBuilderBin);
         const ctx = new ElevateContext('def foo(): pass');
-        await assert.rejects(() => stage.run(ctx), /ctx.parsed is not set/);
+        await assert.rejects(() => stage.run(ctx, logger), /ctx.parsed is not set/);
     });
 
     test('populates ctx.prompt from real parser output', async () => {
@@ -242,8 +247,8 @@ suite('PromptBuilderStage (integration)', () => {
         }
 
         const ctx = new ElevateContext('def add(a, b):\n    return a + b\n');
-        await new ParseStage(parserBin).run(ctx);
-        await new PromptBuilderStage(promptBuilderBin).run(ctx);
+        await new ParseStage(parserBin).run(ctx, logger);
+        await new PromptBuilderStage(promptBuilderBin).run(ctx, logger);
 
         assert.ok(Array.isArray(ctx.prompt) && ctx.prompt!.length > 0, 'ctx.prompt should be set');
         assert.ok(ctx.prompt![0].content.includes('Role:'), 'prompt should include Role section from prompt_builder');


### PR DESCRIPTION
## Summary
- `EditListener` now filters non-file documents at the source (`onTextDocumentChanged` and `onTextDocumentSaved`) so output channels, git diffs, etc. never schedule debounces or trigger callbacks — this was causing a runaway feedback loop where logging to the output channel triggered another pipeline run
- Added a second scheme guard in `extension.ts` `onEdit` callback as a safety net
- Pass `Logger` through `Stage.run()` so each stage can log its own progress
- `ParseStage` logs char count in and block event count out
- `PromptBuilderStage` logs block event count and calls `logPrompt`
- `OllamaStage` logs which model it's sending to and calls `logResponseFinal` 

## Test plan
- [ ] All 29 tests pass (`npm test`)
- [ ] Opening the extension host produces no runaway pipeline runs in the output channel
- [ ] Editing a real `.py` file triggers the pipeline once per debounce cycle
- [ ] Output channel shows ParseStage char/event counts, the prompt sent to Ollama, and the final response