### PR TITLE
feat: add POST /v1/prompt synchronous pipeline endpoint

### DIFF
--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -103,6 +103,37 @@ export class ElevateCore {
       HttpServer.json(res, 200, result);
     });
 
+    router.add("POST", "/v1/prompt", async (_req, res, ctx) => {
+      const body = await ctx.bodyJson<{ parsed: any; text?: string }>();
+
+      if (!body?.parsed) {
+        return HttpServer.json(res, 400, {
+          error: "bad_request",
+          message: "Request body must include a 'parsed' field",
+        });
+      }
+
+      const elevateCtx = new ElevateContext(body.text ?? "");
+      elevateCtx.parsed = body.parsed;
+      elevateCtx.analysisTarget = body.text ?? "";
+
+      const promptBuilderBin = path.join(this.context.extensionUri.fsPath, "cpp_native", "build", "bin", "prompt_builder");
+
+      try {
+        await new PromptBuilderStage(promptBuilderBin).run(elevateCtx, this.logger);
+        await new OllamaStage(this.ollama).run(elevateCtx, this.logger);
+      } catch (e: any) {
+        return HttpServer.json(res, 500, {
+          error: "pipeline_error",
+          message: String(e?.message ?? e),
+        });
+      }
+
+      HttpServer.json(res, 200, {
+        response: elevateCtx.modelResponse,
+      });
+    });
+
     // SSE events: /v1/jobs/:id/events?after=0
     router.add("GET", "/v1/jobs/:id/events", async (req, res, ctx) => {
       const jobId = ctx.params.id;


### PR DESCRIPTION
## Summary
- Adds `POST /v1/prompt` route to `ElevateCore` that accepts `{ parsed, text }` and returns the LLM response synchronously
- Bypasses the job queue — runs `PromptBuilderStage` and `OllamaStage` directly for prompt-driven requests
- Uses the same `prompt_builder` binary path and logger as the existing pipeline

## Test plan
- [ ] POST `http://127.0.0.1:34345/v1/prompt` with a valid `parsed` payload and confirm `{ response: "..." }` is returned
- [ ] POST with missing `parsed` field and confirm 400 error response
- [ ] Trigger a stage error (e.g. bad binary path) and confirm 500 error response

