### PR TITLE
feat: implement communication layer in ExtensionController

### DIFF
--- a/elevate/src/extension.ts
+++ b/elevate/src/extension.ts
@@ -29,8 +29,19 @@ export async function activate(context: vscode.ExtensionContext) {
     );
   }
 
-  const controller = new ExtensionController(backend);
+  const controller = new ExtensionController(backend, logger);
   controller.activateOpenFileListener(context);
+  context.subscriptions.push(controller);
+
+  // Next sprint: response panel — receives the model's analysis text and displays it in a UI panel.
+  controller.onAnalysisComplete((_result) => {
+    // TODO next sprint: responsePanel.update(_result.modelResponse);
+  });
+
+  // Next sprint: diagnostics — parses the model response and pushes inline squiggles to the editor.
+  controller.onAnalysisComplete((_result) => {
+    // TODO next sprint: diagnosticsProvider.set(_result.uri, _result.modelResponse);
+  });
 
   const cfg = vscode.workspace.getConfiguration("elevate");
 

--- a/elevate/src/extension/ExtensionController.ts
+++ b/elevate/src/extension/ExtensionController.ts
@@ -1,21 +1,70 @@
 import * as vscode from 'vscode';
 import { ElevateContext } from '../backend/ElevateContext';
 import { ElevateCore } from '../backend/ElevateCore';
+import { FileSnapshot } from '../backend/FileSnapshot';
 import { Logger } from '../Logger';
 import { EditListener } from '../editListener';
 
-export class ExtensionController {
-    private logger = new Logger();
+// The result produced after a full pipeline run — passed to VSCode via the event below.
+export interface AnalysisResult {
+    uri: string;           // file that was analysed
+    modelResponse: string; // text returned by Ollama
+    snapshot?: FileSnapshot;
+}
 
-    constructor(private readonly backend: ElevateCore) {}
+// ExtensionController is the communication layer between VSCode events (file open, save)
+// and the backend pipeline. It listens for editor events, sends the file content through
+// the pipeline, then fires onAnalysisComplete so the rest of the extension can react.
+export class ExtensionController implements vscode.Disposable {
+    // Internal emitter — only this class fires it.
+    private readonly _onAnalysisComplete = new vscode.EventEmitter<AnalysisResult>();
+
+    // Public event — next sprint the response panel and diagnostics provider subscribe here
+    // to receive analysis results without needing to know how they were produced.
+    public readonly onAnalysisComplete = this._onAnalysisComplete.event;
+
+    constructor(
+        private readonly backend: ElevateCore,
+        private readonly logger: Logger,
+    ) {}
+
+    // Called every time a pipeline run succeeds and produces a model response.
+    // Fires onAnalysisComplete so all subscribers are notified.
+    // Next sprint: add response panel update and diagnostics/squiggles here.
+    private handleAnalysisComplete(result: AnalysisResult): void {
+        this._onAnalysisComplete.fire(result);
+        // TODO next sprint: update response panel, push diagnostics/squiggles
+    }
+
+    public dispose(): void {
+        this._onAnalysisComplete.dispose();
+    }
 
     public activateOpenFileListener(context: vscode.ExtensionContext): void {
         const openFileListener = vscode.workspace.onDidOpenTextDocument(
             async (document: vscode.TextDocument) => {
                 if (document.uri.scheme !== 'file') return;
 
+                this.logger.info(`[analysis] started for: ${document.uri.toString()}`);
                 const ctx = new ElevateContext(document);
-                await this.backend.runPipeline(ctx);
+
+                try {
+                    await this.backend.runPipeline(ctx);
+                } catch (err: any) {
+                    this.logger.error(`[analysis] pipeline error: ${err?.message ?? String(err)}`);
+                    return;
+                }
+
+                if (ctx.modelResponse) {
+                    this.logger.logResponseFinal(ctx.modelResponse);
+                    this.handleAnalysisComplete({
+                        uri: ctx.snapshot?.uri ?? document.uri.toString(),
+                        modelResponse: ctx.modelResponse,
+                        snapshot: ctx.snapshot,
+                    });
+                } else {
+                    this.logger.info('[analysis] pipeline completed with no model response.');
+                }
             }
         );
 
@@ -24,12 +73,29 @@ export class ExtensionController {
 
     public activateSaveListener(context: vscode.ExtensionContext): void {
         const listener = new EditListener(this.logger, {
-            debounceMs: 0,  // no debouncing, immediate
-            fsWatcherEnabled: false, //optional, skip file system watcher
-            onEdit: (doc) => {
+            debounceMs: 0,
+            fsWatcherEnabled: false,
+            onEdit: async (doc) => {
+                this.logger.info(`[analysis] started on save: ${doc.uri.toString()} (version=${doc.version})`);
                 const ctx = new ElevateContext(doc);
-                this.backend.runPipeline(ctx);
-                this.logger.info('[analysis] ran on save: ' + doc.uri.toString() + ' (version=' + doc.version + ')');
+
+                try {
+                    await this.backend.runPipeline(ctx);
+                } catch (err: any) {
+                    this.logger.error(`[analysis] pipeline error: ${err?.message ?? String(err)}`);
+                    return;
+                }
+
+                if (ctx.modelResponse) {
+                    this.logger.logResponseFinal(ctx.modelResponse);
+                    this.handleAnalysisComplete({
+                        uri: ctx.snapshot?.uri ?? doc.uri.toString(),
+                        modelResponse: ctx.modelResponse,
+                        snapshot: ctx.snapshot,
+                    });
+                } else {
+                    this.logger.info('[analysis] pipeline completed with no model response.');
+                }
             },
         });
 


### PR DESCRIPTION
## Summary
- Adds `AnalysisResult` interface and `vscode.EventEmitter` to `ExtensionController` for broadcasting pipeline results
- Constructor now accepts a shared `Logger` instead of creating a duplicate output channel
- Both `activateOpenFileListener` and `activateSaveListener` now properly `await` the pipeline, handle errors, and fire `onAnalysisComplete` on success
- Implements `vscode.Disposable` so the controller cleans up on deactivation
- Adds subscriber stubs in `extension.ts` for the response panel and diagnostics provider (next sprint)
- Pushes controller to `context.subscriptions` for proper lifecycle management

## Test plan
- [x] All 29 tests passing
- [x] Open a Python file in VS Code and confirm analysis runs and logs `"Final response from Ollama"` in the output channel
- [x] Confirm extension deactivates cleanly without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)