### PR TITLE
feat: add whole-file fallback in parser when no block events detected

### DIFF
--- a/elevate/cpp_native/parser/src/parserMain.cpp
+++ b/elevate/cpp_native/parser/src/parserMain.cpp
@@ -25,6 +25,36 @@ int main(int argc, char *argv[])
 
     vector<BlockEvent> events = Parser::parseFile(file);
 
+    // Base case: if no block events were produced, re-read the file and emit
+    // each line as a LINE event so downstream stages always have content to work with.
+    bool hasBlocks = false;
+    for (const auto &e : events)
+        if (e.kind == EventKind::START) { hasBlocks = true; break; }
+
+    if (!hasBlocks)
+    {
+        events.clear();
+        file.clear();
+        file.seekg(0);
+
+        string line;
+        int lineNumber = 0;
+        while (getline(file, line))
+        {
+            lineNumber++;
+            string trimmed = Parser::trim(line);
+            if (trimmed.empty()) continue;
+
+            BlockEvent lineEvent;
+            lineEvent.kind = EventKind::LINE;
+            lineEvent.type = BlockType::UNKNOWN;
+            lineEvent.lineNumber = lineNumber;
+            lineEvent.indentLevel = Parser::countIndent(line);
+            lineEvent.lineText = trimmed;
+            events.push_back(lineEvent);
+        }
+    }
+
     json output = json::array();
 
     for (const auto &event : events)


### PR DESCRIPTION
## Summary
- When a Python file has no block-level constructs (`def`, `class`, `if`, `for`, etc.), the C++ parser now re-reads the file and emits all non-empty lines as `LINE` events
- Fixes the case where flat/procedural scripts (like `sprint_chart.py`) produced 0 events, causing Ollama to receive an empty array and respond asking for data

## Test plan
- [x] Save a Python file with no block structures (e.g. a script with only assignments and function calls)
- [x] Verify the pipeline log shows non-zero block events
- [x] Verify Ollama returns a meaningful analysis instead of asking for JSON data