### PR TITLE
fix: remove duplicate logResponseFinal in OllamaStage

### DIFF
--- a/elevate/src/pipeline/Stage.ts
+++ b/elevate/src/pipeline/Stage.ts
@@ -160,8 +160,6 @@ export class OllamaStage implements Stage {
             }
         }
 
-        logger.logResponseFinal(response);
-
         ctx.modelResponse = response;
     }
 }


### PR DESCRIPTION
## Summary
- `OllamaStage` was calling `logger.logResponseFinal()` after streaming, but `ExtensionController` also calls it after `runPipeline` returns — causing the final response to appear twice in the output channel.
- Removed the redundant call from `OllamaStage`; the controller is the right owner since it has file URI context.

## Test plan
- [x] Open or save a Python file and confirm the final response appears only once in the ELEVATE output channel.