### PR TITLE
feat: add response panel with structured analysis display

### DIFF
--- a/elevate/package.json
+++ b/elevate/package.json
@@ -40,6 +40,10 @@
       {
         "command": "elevate.showCursorPosition",
         "title": "ELEVATE: Show Cursor Position"
+      },
+      {
+        "command": "elevate.openResponsePanel",
+        "title": "ELEVATE: Open Response Panel"
       }
     ],
     "configuration": {

--- a/elevate/src/extension.ts
+++ b/elevate/src/extension.ts
@@ -38,6 +38,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const controller = new ExtensionController(backend, logger);
   controller.activateStatusBar(context);
+  controller.activateResponsePanel(context);
   controller.activateOpenFileListener(context);
   context.subscriptions.push(controller);
 
@@ -49,10 +50,11 @@ export async function activate(context: vscode.ExtensionContext) {
     stateManager.getSession().addFeedback(result.modelResponse);
   });
 
-  // Next sprint: response panel — receives the model's analysis text and displays it in a UI panel.
-  controller.onAnalysisComplete((_result) => {
-    // TODO next sprint: responsePanel.update(_result.modelResponse);
-  });
+  context.subscriptions.push(
+    vscode.commands.registerCommand("elevate.openResponsePanel", () => {
+      controller.showResponsePanel();
+    })
+  );
 
   // Next sprint: diagnostics — parses the model response and pushes inline squiggles to the editor.
   controller.onAnalysisComplete((_result) => {

--- a/elevate/src/extension/ExtensionController.ts
+++ b/elevate/src/extension/ExtensionController.ts
@@ -4,6 +4,7 @@ import { ElevateCore } from '../backend/ElevateCore';
 import { FileSnapshot } from '../backend/FileSnapshot';
 import { Logger } from '../util/Logger';
 import { EditListener } from './editListener';
+import { ResponsePanel } from './ResponsePanel';
 
 // The result produced after a full pipeline run — passed to VSCode via the event below.
 export interface AnalysisResult {
@@ -24,6 +25,7 @@ export class ExtensionController implements vscode.Disposable {
     public readonly onAnalysisComplete = this._onAnalysisComplete.event;
 
     private statusBar?: vscode.StatusBarItem;
+    private responsePanel?: ResponsePanel;
 
     constructor(
         private readonly backend: ElevateCore,
@@ -32,11 +34,20 @@ export class ExtensionController implements vscode.Disposable {
 
     // Called every time a pipeline run succeeds and produces a model response.
     // Fires onAnalysisComplete so all subscribers are notified.
-    // Next sprint: add response panel update and diagnostics/squiggles here.
     private handleAnalysisComplete(result: AnalysisResult): void {
         this.logger.info(`[analysis] complete for: ${result.uri} (${result.modelResponse.length} chars)`);
         this._onAnalysisComplete.fire(result);
-        // TODO next sprint: update response panel, push diagnostics/squiggles
+        this.responsePanel?.update(result.modelResponse);
+        // TODO next sprint: push diagnostics/squiggles
+    }
+
+    public activateResponsePanel(context: vscode.ExtensionContext): void {
+        this.responsePanel = new ResponsePanel(context);
+        context.subscriptions.push(this.responsePanel);
+    }
+
+    public showResponsePanel(): void {
+        this.responsePanel?.show();
     }
 
     public dispose(): void {

--- a/elevate/src/extension/ResponsePanel.ts
+++ b/elevate/src/extension/ResponsePanel.ts
@@ -104,11 +104,12 @@ export class ResponsePanel implements vscode.Disposable {
         }
         h2:first-child { margin-top: 0; }
         p { margin: 0 0 8px 0; }
-        .issue {
-            display: flex;
-            align-items: baseline;
-            gap: 8px;
-            padding: 4px 0;
+        .issues-list {
+            display: grid;
+            grid-template-columns: auto auto 1fr;
+            column-gap: 8px;
+            row-gap: 5px;
+            align-items: center;
         }
         .badge {
             font-size: 0.75em;
@@ -116,12 +117,12 @@ export class ResponsePanel implements vscode.Disposable {
             padding: 1px 6px;
             border-radius: 3px;
             text-transform: uppercase;
-            flex-shrink: 0;
+            text-align: center;
         }
         .badge-error   { background: var(--vscode-inputValidation-errorBackground, #5a1d1d); color: var(--vscode-inputValidation-errorForeground, #f48771); }
         .badge-warning { background: var(--vscode-inputValidation-warningBackground, #352a05); color: var(--vscode-inputValidation-warningForeground, #cca700); }
         .badge-info    { background: var(--vscode-inputValidation-infoBackground, #063b49); color: var(--vscode-inputValidation-infoForeground, #75beff); }
-        .line-num { color: var(--vscode-descriptionForeground); font-size: 0.85em; flex-shrink: 0; }
+        .line-num { color: var(--vscode-descriptionForeground); font-size: 0.85em; white-space: nowrap; }
         .improvement { margin-bottom: 10px; }
         .improvement .reasoning { color: var(--vscode-descriptionForeground); font-size: 0.9em; margin-top: 2px; }
         .raw { white-space: pre-wrap; word-wrap: break-word; }
@@ -137,11 +138,14 @@ export class ResponsePanel implements vscode.Disposable {
     }
 
     private buildStructuredBody(data: AnalysisResponse): string {
-        const issues = data.issues.map(issue => {
-            const badge = `<span class="badge badge-${this.escape(issue.severity)}">${this.escape(issue.severity)}</span>`;
-            const line = `<span class="line-num">line ${issue.line}</span>`;
-            return `<div class="issue">${badge}${line}<span>${this.escape(issue.description)}</span></div>`;
-        }).join('') || '<p>No issues found.</p>';
+        const issueRows = data.issues.map(issue =>
+            `<span class="badge badge-${this.escape(issue.severity)}">${this.escape(issue.severity)}</span>` +
+            `<span class="line-num">line ${issue.line}</span>` +
+            `<span>${this.escape(issue.description)}</span>`
+        ).join('');
+        const issues = issueRows
+            ? `<div class="issues-list">${issueRows}</div>`
+            : '<p>No issues found.</p>';
 
         const improvements = data.improvements.map(imp => `
             <div class="improvement">

--- a/elevate/src/extension/ResponsePanel.ts
+++ b/elevate/src/extension/ResponsePanel.ts
@@ -1,5 +1,23 @@
 import * as vscode from 'vscode';
 
+interface AnalysisIssue {
+    line: number;
+    severity: 'error' | 'warning' | 'info';
+    description: string;
+}
+
+interface AnalysisImprovement {
+    description: string;
+    reasoning: string;
+}
+
+interface AnalysisResponse {
+    structural_summary: string;
+    issues: AnalysisIssue[];
+    complexity: string;
+    improvements: AnalysisImprovement[];
+}
+
 // ResponsePanel renders model analysis output in a VS Code Webview panel beside
 // the active editor. Call update() to create or refresh it without stealing focus.
 export class ResponsePanel implements vscode.Disposable {
@@ -29,11 +47,33 @@ export class ResponsePanel implements vscode.Disposable {
         this.panel?.reveal(vscode.ViewColumn.Beside, true);
     }
 
-    private buildHtml(content: string): string {
-        const escaped = content
+    private parseResponse(raw: string): AnalysisResponse | null {
+        try {
+            const parsed = JSON.parse(raw);
+            if (
+                typeof parsed.structural_summary === 'string' &&
+                Array.isArray(parsed.issues) &&
+                typeof parsed.complexity === 'string' &&
+                Array.isArray(parsed.improvements)
+            ) {
+                return parsed as AnalysisResponse;
+            }
+            return null;
+        } catch {
+            return null;
+        }
+    }
+
+    private escape(text: string): string {
+        return text
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;');
+    }
+
+    private buildHtml(content: string): string {
+        const data = this.parseResponse(content);
+        const body = data ? this.buildStructuredBody(data) : this.buildFallbackBody(content);
 
         return `<!DOCTYPE html>
 <html lang="en">
@@ -50,25 +90,81 @@ export class ResponsePanel implements vscode.Disposable {
             background: var(--vscode-editor-background);
             padding: 16px 20px;
             line-height: 1.6;
-            white-space: pre-wrap;
-            word-wrap: break-word;
             margin: 0;
         }
-        h1 {
-            font-size: 1em;
+        h2 {
+            font-size: 0.85em;
             font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
             color: var(--vscode-descriptionForeground);
-            margin: 0 0 12px 0;
-            padding-bottom: 6px;
+            margin: 20px 0 8px 0;
+            padding-bottom: 4px;
             border-bottom: 1px solid var(--vscode-panel-border);
+        }
+        h2:first-child { margin-top: 0; }
+        p { margin: 0 0 8px 0; }
+        .issue {
+            display: flex;
+            align-items: baseline;
+            gap: 8px;
+            padding: 4px 0;
+        }
+        .badge {
+            font-size: 0.75em;
+            font-weight: 600;
+            padding: 1px 6px;
+            border-radius: 3px;
+            text-transform: uppercase;
+            flex-shrink: 0;
+        }
+        .badge-error   { background: var(--vscode-inputValidation-errorBackground, #5a1d1d); color: var(--vscode-inputValidation-errorForeground, #f48771); }
+        .badge-warning { background: var(--vscode-inputValidation-warningBackground, #352a05); color: var(--vscode-inputValidation-warningForeground, #cca700); }
+        .badge-info    { background: var(--vscode-inputValidation-infoBackground, #063b49); color: var(--vscode-inputValidation-infoForeground, #75beff); }
+        .line-num { color: var(--vscode-descriptionForeground); font-size: 0.85em; flex-shrink: 0; }
+        .improvement { margin-bottom: 10px; }
+        .improvement .reasoning { color: var(--vscode-descriptionForeground); font-size: 0.9em; margin-top: 2px; }
+        .raw { white-space: pre-wrap; word-wrap: break-word; }
+        .parse-warning {
+            font-size: 0.8em;
+            color: var(--vscode-inputValidation-warningForeground, #cca700);
+            margin-bottom: 12px;
         }
     </style>
 </head>
-<body>
-    <h1>ELEVATE Analysis</h1>
-    <div>${escaped}</div>
-</body>
+<body>${body}</body>
 </html>`;
+    }
+
+    private buildStructuredBody(data: AnalysisResponse): string {
+        const issues = data.issues.map(issue => {
+            const badge = `<span class="badge badge-${this.escape(issue.severity)}">${this.escape(issue.severity)}</span>`;
+            const line = `<span class="line-num">line ${issue.line}</span>`;
+            return `<div class="issue">${badge}${line}<span>${this.escape(issue.description)}</span></div>`;
+        }).join('') || '<p>No issues found.</p>';
+
+        const improvements = data.improvements.map(imp => `
+            <div class="improvement">
+                <div>${this.escape(imp.description)}</div>
+                <div class="reasoning">${this.escape(imp.reasoning)}</div>
+            </div>`
+        ).join('') || '<p>No improvements suggested.</p>';
+
+        return `
+            <h2>Summary</h2>
+            <p>${this.escape(data.structural_summary)}</p>
+            <h2>Issues</h2>
+            ${issues}
+            <h2>Complexity</h2>
+            <p>${this.escape(data.complexity)}</p>
+            <h2>Improvements</h2>
+            ${improvements}`;
+    }
+
+    private buildFallbackBody(content: string): string {
+        return `
+            <p class="parse-warning">Could not parse structured response — showing raw output.</p>
+            <div class="raw">${this.escape(content)}</div>`;
     }
 
     public dispose(): void {

--- a/elevate/src/extension/ResponsePanel.ts
+++ b/elevate/src/extension/ResponsePanel.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+
+// ResponsePanel renders model analysis output in a VS Code Webview panel beside
+// the active editor. Call update() to create or refresh it without stealing focus.
+export class ResponsePanel implements vscode.Disposable {
+    private static readonly viewType = 'elevate.responsePanel';
+    private panel: vscode.WebviewPanel | undefined;
+
+    constructor(private readonly context: vscode.ExtensionContext) {}
+
+    public update(modelResponse: string): void {
+        if (!this.panel) {
+            this.panel = vscode.window.createWebviewPanel(
+                ResponsePanel.viewType,
+                'ELEVATE: Analysis',
+                { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+                { enableScripts: false, retainContextWhenHidden: true },
+            );
+            this.panel.onDidDispose(() => {
+                this.panel = undefined;
+            }, null, this.context.subscriptions);
+        } else {
+            this.panel.reveal(vscode.ViewColumn.Beside, /* preserveFocus */ true);
+        }
+        this.panel.webview.html = this.buildHtml(modelResponse);
+    }
+
+    public show(): void {
+        this.panel?.reveal(vscode.ViewColumn.Beside, true);
+    }
+
+    private buildHtml(content: string): string {
+        const escaped = content
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ELEVATE Analysis</title>
+    <style>
+        body {
+            font-family: var(--vscode-font-family);
+            font-size: var(--vscode-font-size);
+            color: var(--vscode-editor-foreground);
+            background: var(--vscode-editor-background);
+            padding: 16px 20px;
+            line-height: 1.6;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            margin: 0;
+        }
+        h1 {
+            font-size: 1em;
+            font-weight: 600;
+            color: var(--vscode-descriptionForeground);
+            margin: 0 0 12px 0;
+            padding-bottom: 6px;
+            border-bottom: 1px solid var(--vscode-panel-border);
+        }
+    </style>
+</head>
+<body>
+    <h1>ELEVATE Analysis</h1>
+    <div>${escaped}</div>
+</body>
+</html>`;
+    }
+
+    public dispose(): void {
+        this.panel?.dispose();
+    }
+}

--- a/elevate/src/extension/ResponsePanel.ts
+++ b/elevate/src/extension/ResponsePanel.ts
@@ -93,11 +93,11 @@ export class ResponsePanel implements vscode.Disposable {
             margin: 0;
         }
         h2 {
-            font-size: 0.85em;
-            font-weight: 600;
+            font-size: 1em;
+            font-weight: 700;
             text-transform: uppercase;
             letter-spacing: 0.06em;
-            color: var(--vscode-descriptionForeground);
+            color: var(--vscode-editor-foreground);
             margin: 20px 0 8px 0;
             padding-bottom: 4px;
             border-bottom: 1px solid var(--vscode-panel-border);

--- a/elevate/src/extension/ResponsePanel.ts
+++ b/elevate/src/extension/ResponsePanel.ts
@@ -79,7 +79,7 @@ export class ResponsePanel implements vscode.Disposable {
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ELEVATE Analysis</title>
     <style>


### PR DESCRIPTION
## Summary
- Adds a `ResponsePanel` webview that renders model analysis output beside the active editor
- Parses structured JSON responses (summary, issues, complexity, improvements) into a formatted UI with severity badges and a CSS grid issues list
- Falls back to raw text display for unparseable responses
- Section headers styled bold for visual clarity

## Test plan
- [ ] Open a file and trigger analysis — confirm panel opens beside editor without stealing focus
- [ ] Verify structured response renders with correct sections and severity badge colors
- [ ] Verify raw fallback renders with parse warning for invalid JSON
- [ ] Confirm panel persists and updates on subsequent analyses