### PR TITLE
feat: warn user when Ollama is not running on activation

### DIFF
--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -218,6 +218,15 @@ export class ElevateCore {
     return { ok: true, ollama_url: vscode.workspace.getConfiguration("elevate").get("ollamaUrl") ?? "http://localhost:11434" };
   }
 
+  async checkOllama(): Promise<boolean> {
+    try {
+      await this.ollama.tags();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async enqueueChatJob(args: { priority: number; model: string; messages: any[]; keep_alive?: string; options?: any }) {
     return this.queue.enqueueChatJob(args as any);
   }

--- a/elevate/src/extension.ts
+++ b/elevate/src/extension.ts
@@ -33,6 +33,19 @@ export async function activate(context: vscode.ExtensionContext) {
     );
   }
 
+  // Check if Ollama is reachable and warn the user if not.
+  const ollamaReachable = await backend.checkOllama();
+  if (!ollamaReachable) {
+    output.appendLine("[ELEVATE] Ollama is not reachable.");
+    const action = await vscode.window.showWarningMessage(
+      "ELEVATE: Ollama is not running. Start it with `ollama serve`, or enable \"Launch at Login\" in the Ollama menu bar app.",
+      "Open Ollama Docs"
+    );
+    if (action === "Open Ollama Docs") {
+      vscode.env.openExternal(vscode.Uri.parse("https://ollama.com/download"));
+    }
+  }
+
   const stateManager = new CoreStateManager();
   stateManager.initialize();
 


### PR DESCRIPTION
## Summary
- Adds `checkOllama()` to `ElevateCore` that pings `/api/tags` to detect if Ollama is reachable
- On activation, if Ollama is unreachable, shows an actionable warning message with an "Open Ollama Docs" button
- Helps users (especially on Mac) who need to run `ollama serve` or enable "Launch at Login" in the Ollama desktop app

## Test plan
- [ ] Install the extension with Ollama not running — warning message should appear on activation
- [ ] Click "Open Ollama Docs" — should open the Ollama download page in the browser
- [ ] Start Ollama, reload VS Code — no warning should appear