### PR TITLE
feat: inline diagnostics (squiggles) from Ollama analysis

### DIFF
--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -245,13 +245,19 @@ export class ElevateCore {
   async runPipeline(ctx: ElevateContext): Promise<void> {
     await this.pipeline.execute(ctx);
 
-    if (!ctx.modelResponse || !ctx.snapshot?.uri) return;
+    if (!ctx.snapshot?.uri) return;
 
     const uri = vscode.Uri.parse(ctx.snapshot.uri);
-    const diagnostics = parseModelResponse(ctx.modelResponse);
+    const diagnostics = ctx.analysisResult
+      ? ctx.analysisResult.issues.map(issue => new vscode.Diagnostic(
+          new vscode.Range(issue.line - 1, 0, issue.line - 1, Number.MAX_SAFE_INTEGER),
+          issue.description,
+          resolveSeverity(issue.severity)
+        ))
+      : [];
     this.diagnosticCollection.set(uri, diagnostics);
     ctx.diagnostics = diagnostics;
-}
+  }
 
   async waitForTerminalStatus(jobId: string): Promise<JobRecord> {
     while (true) {
@@ -264,42 +270,6 @@ export class ElevateCore {
       await new Promise((r) => setTimeout(r, 100));
     }
   }
-}
-
-function parseModelResponse(response: string): vscode.Diagnostic[] {
-  const results: vscode.Diagnostic[] = [];
-
-  const lineFirst = /\bline\s+(\d+)\s*[:\-]\s*([\w\s]+?)\s*[:\-]\s*(.+)/gi;
-  const severityFirst = /\b(error|warning|warn|hint|suggestion|note|info|critical|fatal)\s+(?:on|at)\s+line\s+(\d+)\s*[:\-]?\s*(.+)/gi;
-
-  for (const match of response.matchAll(lineFirst)) {
-    const line = parseInt(match[1], 10) - 1;
-    const severity = resolveSeverity(match[2].trim().toLowerCase());
-    const message = match[3].trim();
-    if (line < 0 || !message) continue;
-    results.push(new vscode.Diagnostic(
-      new vscode.Range(line, 0, line, Number.MAX_SAFE_INTEGER),
-      message,
-      severity
-    ));
-  }
-
-  for (const match of response.matchAll(severityFirst)) {
-    const line = parseInt(match[2], 10) - 1;
-    const severity = resolveSeverity(match[1].trim().toLowerCase());
-    const message = match[3].trim();
-    if (line < 0 || !message) continue;
-    const dupe = results.some(d => d.range.start.line === line && d.message === message);
-    if (!dupe) {
-      results.push(new vscode.Diagnostic(
-        new vscode.Range(line, 0, line, Number.MAX_SAFE_INTEGER),
-        message,
-        severity
-      ));
-    }
-  }
-
-  return results;
 }
 
 function resolveSeverity(word: string): vscode.DiagnosticSeverity {

--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -6,14 +6,11 @@ import { JobStore } from "./JobStore";
 import { SseHub } from "./SSEHub";
 import { OllamaClient } from "./OllamaClient";
 import { CreateChatJobRequest, HealthResponse, JobEvent, JobRecord, JobStatus, ModelsResponse } from "./types";
-import { isoNow } from "../util/time";
 import { Pipeline } from "../pipeline/Pipeline";
 import { SanitizationStage, ParseStage, PromptBuilderStage, OllamaStage } from "../pipeline/Stage";
 import { Logger } from "../util/Logger";
 import { ElevateContext } from "./ElevateContext";
 import * as path from "path";
-
-// Test Change to see if I can push
 
 export class ElevateCore {
   private server: HttpServer | null = null;
@@ -23,6 +20,7 @@ export class ElevateCore {
   private ollama: OllamaClient;
   private logger: Logger;
   private pipeline: Pipeline;
+  private diagnosticCollection: vscode.DiagnosticCollection;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -42,9 +40,16 @@ export class ElevateCore {
 
     this.logger = new Logger(output);
     this.pipeline = new Pipeline(
-      [new SanitizationStage(), new ParseStage(parserBin), new PromptBuilderStage(promptBuilderBin), new OllamaStage(this.ollama)],
+      [
+        new SanitizationStage(),
+        new ParseStage(parserBin),
+        new PromptBuilderStage(promptBuilderBin),
+        new OllamaStage(this.ollama),
+      ],
       this.logger
     );
+
+    this.diagnosticCollection = vscode.languages.createDiagnosticCollection("elevate");
 
     // keep file versions on updated save
     vscode.workspace.onDidSaveTextDocument((doc) => {
@@ -214,6 +219,7 @@ export class ElevateCore {
     this.queue.stop();
     void this.server?.close();
     this.server = null;
+    this.diagnosticCollection.dispose();
   }
 
   async health(): Promise<HealthResponse> {
@@ -237,8 +243,15 @@ export class ElevateCore {
   }
 
   async runPipeline(ctx: ElevateContext): Promise<void> {
-    return this.pipeline.execute(ctx);
-  }
+    await this.pipeline.execute(ctx);
+
+    if (!ctx.modelResponse || !ctx.snapshot?.uri) return;
+
+    const uri = vscode.Uri.parse(ctx.snapshot.uri);
+    const diagnostics = parseModelResponse(ctx.modelResponse);
+    this.diagnosticCollection.set(uri, diagnostics);
+    ctx.diagnostics = diagnostics;
+}
 
   async waitForTerminalStatus(jobId: string): Promise<JobRecord> {
     while (true) {
@@ -251,4 +264,47 @@ export class ElevateCore {
       await new Promise((r) => setTimeout(r, 100));
     }
   }
+}
+
+function parseModelResponse(response: string): vscode.Diagnostic[] {
+  const results: vscode.Diagnostic[] = [];
+
+  const lineFirst = /\bline\s+(\d+)\s*[:\-]\s*([\w\s]+?)\s*[:\-]\s*(.+)/gi;
+  const severityFirst = /\b(error|warning|warn|hint|suggestion|note|info|critical|fatal)\s+(?:on|at)\s+line\s+(\d+)\s*[:\-]?\s*(.+)/gi;
+
+  for (const match of response.matchAll(lineFirst)) {
+    const line = parseInt(match[1], 10) - 1;
+    const severity = resolveSeverity(match[2].trim().toLowerCase());
+    const message = match[3].trim();
+    if (line < 0 || !message) continue;
+    results.push(new vscode.Diagnostic(
+      new vscode.Range(line, 0, line, Number.MAX_SAFE_INTEGER),
+      message,
+      severity
+    ));
+  }
+
+  for (const match of response.matchAll(severityFirst)) {
+    const line = parseInt(match[2], 10) - 1;
+    const severity = resolveSeverity(match[1].trim().toLowerCase());
+    const message = match[3].trim();
+    if (line < 0 || !message) continue;
+    const dupe = results.some(d => d.range.start.line === line && d.message === message);
+    if (!dupe) {
+      results.push(new vscode.Diagnostic(
+        new vscode.Range(line, 0, line, Number.MAX_SAFE_INTEGER),
+        message,
+        severity
+      ));
+    }
+  }
+
+  return results;
+}
+
+function resolveSeverity(word: string): vscode.DiagnosticSeverity {
+  if (["error", "critical", "fatal"].some(k => word.includes(k))) return vscode.DiagnosticSeverity.Error;
+  if (["warning", "warn", "caution"].some(k => word.includes(k)))  return vscode.DiagnosticSeverity.Warning;
+  if (["hint", "suggestion", "note", "info"].some(k => word.includes(k))) return vscode.DiagnosticSeverity.Hint;
+  return vscode.DiagnosticSeverity.Information;
 }

--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -13,6 +13,8 @@ import { Logger } from "../util/Logger";
 import { ElevateContext } from "./ElevateContext";
 import * as path from "path";
 
+// Test Change to see if I can push
+
 export class ElevateCore {
   private server: HttpServer | null = null;
   private hub = new SseHub();

--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -62,6 +62,11 @@ export class ElevateCore {
       const key = this.getFileKey(e.document);
       this.queue.setFileVersion(key, e.document.version);
     });
+
+    // clear diagnostics when a file is closed
+    vscode.workspace.onDidCloseTextDocument((doc) => {
+      this.diagnosticCollection.delete(doc.uri);
+    });
   }
 
   // unique key per file
@@ -272,9 +277,10 @@ export class ElevateCore {
   }
 }
 
-function resolveSeverity(word: string): vscode.DiagnosticSeverity {
-  if (["error", "critical", "fatal"].some(k => word.includes(k))) return vscode.DiagnosticSeverity.Error;
-  if (["warning", "warn", "caution"].some(k => word.includes(k)))  return vscode.DiagnosticSeverity.Warning;
-  if (["hint", "suggestion", "note", "info"].some(k => word.includes(k))) return vscode.DiagnosticSeverity.Hint;
-  return vscode.DiagnosticSeverity.Information;
+function resolveSeverity(severity: "error" | "warning" | "info"): vscode.DiagnosticSeverity {
+  switch (severity) {
+    case "error":   return vscode.DiagnosticSeverity.Error;
+    case "warning": return vscode.DiagnosticSeverity.Warning;
+    case "info":    return vscode.DiagnosticSeverity.Information;
+  }
 }

--- a/elevate/src/extension/ExtensionController.ts
+++ b/elevate/src/extension/ExtensionController.ts
@@ -38,7 +38,6 @@ export class ExtensionController implements vscode.Disposable {
         this.logger.info(`[analysis] complete for: ${result.uri} (${result.modelResponse.length} chars)`);
         this._onAnalysisComplete.fire(result);
         this.responsePanel?.update(result.modelResponse);
-        // TODO next sprint: push diagnostics/squiggles
     }
 
     public activateResponsePanel(context: vscode.ExtensionContext): void {

--- a/elevate/src/extension/ExtensionController.ts
+++ b/elevate/src/extension/ExtensionController.ts
@@ -115,7 +115,7 @@ export class ExtensionController implements vscode.Disposable {
                 this.logger.info(`[analysis] started on save: ${doc.uri.toString()} (version=${doc.version})`);
                 if (this.statusBar) this.statusBar.text ='$(sync~spin) Elevate: Analyzing...';
                 const ctx = new ElevateContext(doc);
-                ctx.cursorLine = vscode.window.activeTextEditor?.selection.active.line;
+                // No cursorLine set — analyzes the whole file on save
 
                 try {
                     await this.backend.runPipeline(ctx);


### PR DESCRIPTION
## Summary
- Implements inline VS Code diagnostics from Ollama analysis results (CE-117)
- Adds `DiagnosticCollection` to `ElevateCore` that maps analysis issues to squiggles in the editor
- Clears diagnostics when a file is closed; disposes collection on shutdown
- Switches save-triggered analysis to full-file mode (drops `cursorLine`) and removes stale TODO comment

## Changes
- **ElevateCore.ts**: Create `vscode.DiagnosticCollection`, populate it after each pipeline run, clear on file close, dispose on shutdown. Adds `resolveSeverity` helper.
- **ExtensionController.ts**: Remove `cursorLine` assignment on save (full-file analysis); remove resolved TODO.

## Test plan
- [ ] Open a TypeScript/JS file and trigger a save — confirm squiggles appear on lines flagged by Ollama
- [ ] Close the file — confirm diagnostics are cleared from the Problems panel
- [ ] Reload/deactivate extension — confirm no diagnostic collection leak