### PR TITLE
feat: add user-configurable verbosity, teaching style, and custom rules

### DIFF
--- a/elevate/package.json
+++ b/elevate/package.json
@@ -128,7 +128,7 @@
         "elevate.customRules": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Additional instructions appended to every analysis prompt. Use this to add personal preferences or focus areas (e.g. `Always mention time complexity. Focus on readability over cleverness.`)."
+          "markdownDescription": "Additional instructions appended to every analysis prompt. Enter one rule per line — each line becomes a separate instruction (e.g. `Always mention time complexity.\\nFocus on readability over cleverness.`)."
         }
       }
     }

--- a/elevate/package.json
+++ b/elevate/package.json
@@ -102,6 +102,33 @@
           "type": "string",
           "default": "**/*",
           "description": "Glob for file system watcher."
+        },
+        "elevate.verbosity": {
+          "type": "string",
+          "enum": ["concise", "balanced", "verbose"],
+          "enumDescriptions": [
+            "Short responses — only the most important 2–3 issues, brief explanations.",
+            "Default balanced detail level.",
+            "Thorough responses — explain concepts fully, include all issues found."
+          ],
+          "default": "balanced",
+          "description": "Controls how detailed the analysis feedback is."
+        },
+        "elevate.teachingStyle": {
+          "type": "string",
+          "enum": ["direct", "socratic", "step-by-step"],
+          "enumDescriptions": [
+            "State issues and improvements plainly and directly.",
+            "Phrase issues as guiding questions that lead the student to discover problems themselves.",
+            "Break every explanation into numbered steps, walking the student through reasoning one step at a time."
+          ],
+          "default": "direct",
+          "description": "Controls the instructional style used in feedback."
+        },
+        "elevate.customRules": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Additional instructions appended to every analysis prompt. Use this to add personal preferences or focus areas (e.g. `Always mention time complexity. Focus on readability over cleverness.`)."
         }
       }
     }

--- a/elevate/src/pipeline/Stage.ts
+++ b/elevate/src/pipeline/Stage.ts
@@ -82,6 +82,46 @@ function filterToActiveBlock(events: BlockEvent[], cursorLine?: number): BlockEv
     return blockStart === -1 ? events : events.slice(blockStart, blockEnd);
 }
 
+function applyUserRules(promptText: string): string {
+    const cfg = vscode.workspace.getConfiguration("elevate");
+    const verbosity = cfg.get<string>("verbosity", "balanced");
+    const teachingStyle = cfg.get<string>("teachingStyle", "direct");
+    const customRules = cfg.get<string>("customRules", "").trim();
+
+    const lines: string[] = [];
+
+    if (verbosity === "concise") {
+        lines.push("- Keep all feedback brief. Limit issues to the 2–3 most important. Use short sentences.");
+    } else if (verbosity === "verbose") {
+        lines.push("- Be thorough and detailed. Explain concepts fully. Include all issues you find.");
+    }
+
+    if (teachingStyle === "socratic") {
+        lines.push("- Use a Socratic approach: phrase issues as guiding questions that lead the student to discover the problem themselves.");
+    } else if (teachingStyle === "step-by-step") {
+        lines.push("- Break every explanation into numbered steps, walking the student through reasoning one step at a time.");
+    }
+
+    if (customRules) {
+        lines.push(`- ${customRules}`);
+    }
+
+    if (lines.length === 0) {
+        return promptText;
+    }
+
+    const userRulesSection = "User Preferences:\n" + lines.join("\n") + "\n\n";
+
+    // Insert before the output format section so it doesn't override the JSON schema instruction
+    const marker = "Output Format (STRICT";
+    const markerIdx = promptText.indexOf(marker);
+    if (markerIdx !== -1) {
+        return promptText.slice(0, markerIdx) + userRulesSection + promptText.slice(markerIdx);
+    }
+
+    return promptText + "\n" + userRulesSection;
+}
+
 export class PromptBuilderStage implements Stage {
     name = "Prompt Builder Stage";
 
@@ -114,7 +154,8 @@ export class PromptBuilderStage implements Stage {
             proc.on("error", reject);
         });
 
-        const promptText = await readFile(outputPath, "utf-8");
+        const rawPromptText = await readFile(outputPath, "utf-8");
+        const promptText = applyUserRules(rawPromptText);
 
         ctx.prompt = [{ role: "user", content: promptText }];
 

--- a/elevate/src/pipeline/Stage.ts
+++ b/elevate/src/pipeline/Stage.ts
@@ -82,11 +82,18 @@ function filterToActiveBlock(events: BlockEvent[], cursorLine?: number): BlockEv
     return blockStart === -1 ? events : events.slice(blockStart, blockEnd);
 }
 
-function applyUserRules(promptText: string): string {
-    const cfg = vscode.workspace.getConfiguration("elevate");
-    const verbosity = cfg.get<string>("verbosity", "balanced");
-    const teachingStyle = cfg.get<string>("teachingStyle", "direct");
-    const customRules = cfg.get<string>("customRules", "").trim();
+// Matches the opening of the output format section in cpp_native/prompt_builder/src/template.cpp.
+// If that string changes, injection falls back to appending (which may degrade model output format).
+const OUTPUT_FORMAT_MARKER = "Output Format (STRICT";
+
+export interface UserRulesOptions {
+    verbosity: string;
+    teachingStyle: string;
+    customRules: string;
+}
+
+export function applyUserRules(promptText: string, opts: UserRulesOptions, logger: Logger): string {
+    const { verbosity, teachingStyle, customRules } = opts;
 
     const lines: string[] = [];
 
@@ -103,7 +110,9 @@ function applyUserRules(promptText: string): string {
     }
 
     if (customRules) {
-        lines.push(`- ${customRules}`);
+        for (const rule of customRules.split('\n').map(r => r.trim()).filter(r => r.length > 0)) {
+            lines.push(`- ${rule}`);
+        }
     }
 
     if (lines.length === 0) {
@@ -113,12 +122,14 @@ function applyUserRules(promptText: string): string {
     const userRulesSection = "User Preferences:\n" + lines.join("\n") + "\n\n";
 
     // Insert before the output format section so it doesn't override the JSON schema instruction
-    const marker = "Output Format (STRICT";
-    const markerIdx = promptText.indexOf(marker);
+    const markerIdx = promptText.indexOf(OUTPUT_FORMAT_MARKER);
     if (markerIdx !== -1) {
         return promptText.slice(0, markerIdx) + userRulesSection + promptText.slice(markerIdx);
     }
 
+    // Fallback: marker not found — prompt_builder output may have changed.
+    // Appending after the output format section may degrade JSON compliance.
+    logger.warn("applyUserRules: output format marker not found in prompt — appending user rules at end");
     return promptText + "\n" + userRulesSection;
 }
 
@@ -155,7 +166,12 @@ export class PromptBuilderStage implements Stage {
         });
 
         const rawPromptText = await readFile(outputPath, "utf-8");
-        const promptText = applyUserRules(rawPromptText);
+        const cfg = vscode.workspace.getConfiguration("elevate");
+        const promptText = applyUserRules(rawPromptText, {
+            verbosity: cfg.get<string>("verbosity", "balanced"),
+            teachingStyle: cfg.get<string>("teachingStyle", "direct"),
+            customRules: cfg.get<string>("customRules", "").trim(),
+        }, logger);
 
         ctx.prompt = [{ role: "user", content: promptText }];
 

--- a/elevate/src/test/applyUserRules.test.ts
+++ b/elevate/src/test/applyUserRules.test.ts
@@ -1,0 +1,118 @@
+import * as assert from 'assert';
+import { applyUserRules, UserRulesOptions } from '../pipeline/Stage';
+import { Logger } from '../util/Logger';
+
+suite('applyUserRules', () => {
+    const logger = new Logger('test', false);
+
+    // A minimal prompt that contains the output format marker
+    const BASE_PROMPT = "Role:\nYou are an instructor.\n\nOutput Format (STRICT — follow this):\nReturn JSON only.\n";
+
+    function opts(overrides: Partial<UserRulesOptions> = {}): UserRulesOptions {
+        return {
+            verbosity: 'balanced',
+            teachingStyle: 'direct',
+            customRules: '',
+            ...overrides,
+        };
+    }
+
+    // --- No-op cases ---
+
+    test('returns prompt unchanged when all settings are defaults', () => {
+        const result = applyUserRules(BASE_PROMPT, opts(), logger);
+        assert.strictEqual(result, BASE_PROMPT);
+    });
+
+    test('returns prompt unchanged when verbosity=balanced, teachingStyle=direct, no customRules', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ verbosity: 'balanced', teachingStyle: 'direct' }), logger);
+        assert.strictEqual(result, BASE_PROMPT);
+    });
+
+    // --- Verbosity ---
+
+    test('injects concise instruction when verbosity=concise', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ verbosity: 'concise' }), logger);
+        assert.ok(result.includes('brief'), 'should include brevity instruction');
+        assert.ok(result.includes('2–3 most important'), 'should limit issue count');
+    });
+
+    test('injects verbose instruction when verbosity=verbose', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ verbosity: 'verbose' }), logger);
+        assert.ok(result.includes('thorough and detailed'), 'should include thoroughness instruction');
+    });
+
+    // --- Teaching style ---
+
+    test('injects socratic instruction when teachingStyle=socratic', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ teachingStyle: 'socratic' }), logger);
+        assert.ok(result.includes('Socratic'), 'should include Socratic instruction');
+    });
+
+    test('injects step-by-step instruction when teachingStyle=step-by-step', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ teachingStyle: 'step-by-step' }), logger);
+        assert.ok(result.includes('numbered steps'), 'should include step-by-step instruction');
+    });
+
+    // --- Custom rules ---
+
+    test('appends customRules as a bullet when provided', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ customRules: 'Always mention time complexity.' }), logger);
+        assert.ok(result.includes('- Always mention time complexity.'), 'should include custom rule as bullet');
+    });
+
+    test('splits multi-line customRules into separate bullets', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ customRules: 'Always mention time complexity.\nFocus on readability over cleverness.' }), logger);
+        assert.ok(result.includes('- Always mention time complexity.'), 'should include first rule');
+        assert.ok(result.includes('- Focus on readability over cleverness.'), 'should include second rule');
+    });
+
+    test('ignores blank lines in customRules', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ customRules: 'First rule.\n\n\nSecond rule.' }), logger);
+        assert.ok(result.includes('- First rule.'), 'should include first rule');
+        assert.ok(result.includes('- Second rule.'), 'should include second rule');
+        assert.ok(!result.includes('- \n'), 'should not include blank bullet');
+    });
+
+    test('ignores customRules when empty string', () => {
+        // run() trims customRules before passing to applyUserRules, so we pass already-trimmed input
+        const result = applyUserRules(BASE_PROMPT, opts({ customRules: '' }), logger);
+        assert.strictEqual(result, BASE_PROMPT);
+    });
+
+    // --- Insertion position ---
+
+    test('inserts User Preferences section before the output format marker', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ verbosity: 'concise' }), logger);
+        const prefIdx = result.indexOf('User Preferences:');
+        const markerIdx = result.indexOf('Output Format (STRICT');
+        assert.ok(prefIdx !== -1, 'User Preferences section should be present');
+        assert.ok(prefIdx < markerIdx, 'User Preferences should appear before the output format section');
+    });
+
+    test('falls back to appending when marker is absent', () => {
+        const noMarkerPrompt = "Role:\nYou are an instructor.\n";
+        const result = applyUserRules(noMarkerPrompt, opts({ verbosity: 'verbose' }), logger);
+        assert.ok(result.startsWith(noMarkerPrompt), 'original prompt should be preserved at the start');
+        assert.ok(result.includes('User Preferences:'), 'User Preferences section should still be present');
+    });
+
+    // --- Combined options ---
+
+    test('combines verbosity and teachingStyle instructions', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({ verbosity: 'verbose', teachingStyle: 'socratic' }), logger);
+        assert.ok(result.includes('thorough and detailed'), 'should include verbose instruction');
+        assert.ok(result.includes('Socratic'), 'should include socratic instruction');
+    });
+
+    test('combines all three options', () => {
+        const result = applyUserRules(BASE_PROMPT, opts({
+            verbosity: 'concise',
+            teachingStyle: 'step-by-step',
+            customRules: 'Focus on readability.',
+        }), logger);
+        assert.ok(result.includes('brief'), 'should include verbosity instruction');
+        assert.ok(result.includes('numbered steps'), 'should include teaching style instruction');
+        assert.ok(result.includes('Focus on readability.'), 'should include custom rule');
+    });
+});


### PR DESCRIPTION
Users can now customize analysis feedback via VS Code settings:
- elevate.verbosity (concise | balanced | verbose)
- elevate.teachingStyle (direct | socratic | step-by-step)
- elevate.customRules (freeform prompt instructions)

Settings are injected into the prompt at runtime by applyUserRules() in PromptBuilderStage, inserted before the JSON output format section.