### PR TITLE
feat: switch default model to qwen2.5-coder

### DIFF
--- a/elevate/package.json
+++ b/elevate/package.json
@@ -68,7 +68,7 @@
         },
         "elevate.defaultModel": {
           "type": "string",
-          "default": "llama3.2:3b",
+          "default": "qwen2.5-coder:latest",
           "description": "Default Ollama model name"
         },
         "elevate.cursorTracking.enabled": {

--- a/elevate/src/extension.ts
+++ b/elevate/src/extension.ts
@@ -146,7 +146,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (!backend) return;
 
       const cfg = vscode.workspace.getConfiguration("elevate");
-      const model = cfg.get<string>("defaultModel") ?? "llama3.1:latest";
+      const model = cfg.get<string>("defaultModel") ?? "qwen2.5-coder:latest";
 
       const prompt = await vscode.window.showInputBox({
         title: "ELEVATE (Ollama)",

--- a/elevate/src/pipeline/Stage.ts
+++ b/elevate/src/pipeline/Stage.ts
@@ -166,7 +166,7 @@ export class OllamaStage implements Stage {
         /*
          * Requires ctx.prompt to be populated by PromptBuilderStage.
          * Reads the target model from VSCode settings (elevate.defaultModel),
-         * falling back to llama3.2:3b.
+         * falling back to qwen2.5-coder:latest.
          * Streams the response from Ollama chunk by chunk, accumulating
          * the full text, then stores it in ctx.modelResponse for the caller.
          * If the response fails JSON validation, retries once with a correction message.
@@ -177,7 +177,7 @@ export class OllamaStage implements Stage {
 
         const model = vscode.workspace
             .getConfiguration("elevate")
-            .get<string>("defaultModel") ?? "llama3.2:3b";
+            .get<string>("defaultModel") ?? "qwen2.5-coder:latest";
 
         logger.info(`OllamaStage: sending prompt to model "${model}"`);
 


### PR DESCRIPTION
## Summary
- Replaces `llama3.2:3b` / `llama3.1:latest` with `qwen2.5-coder:latest` as the default Ollama model
- Updated in `package.json` (setting default), `Stage.ts` (OllamaStage fallback), and `extension.ts` (command handler fallback)

> **Note:** Ensure `qwen2.5-coder:latest` is pulled on any machine running the extension: `ollama pull qwen2.5-coder:latest`

## Test plan
- [ ] Verify analysis runs end-to-end with `qwen2.5-coder:latest`
- [ ] Verify JSON response is parsed correctly and diagnostics appear
- [ ] Verify `elevate.defaultModel` setting still overrides the default as expected