### PR TITLE
fix: resolve all functional TODO items

### DIFF
--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -7,7 +7,7 @@ import { SseHub } from "./SSEHub";
 import { OllamaClient } from "./OllamaClient";
 import { CreateChatJobRequest, HealthResponse, JobEvent, JobRecord, JobStatus, ModelsResponse } from "./types";
 import { Pipeline } from "../pipeline/Pipeline";
-import { SanitizationStage, ParseStage, PromptBuilderStage, OllamaStage } from "../pipeline/Stage";
+import { ParseStage, PromptBuilderStage, OllamaStage } from "../pipeline/Stage";
 import { Logger } from "../util/Logger";
 import { ElevateContext } from "./ElevateContext";
 import * as path from "path";
@@ -41,7 +41,6 @@ export class ElevateCore {
     this.logger = new Logger(output);
     this.pipeline = new Pipeline(
       [
-        new SanitizationStage(),
         new ParseStage(parserBin),
         new PromptBuilderStage(promptBuilderBin),
         new OllamaStage(this.ollama),

--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -274,16 +274,37 @@ export class ElevateCore {
     ctx.diagnostics = diagnostics;
   }
 
-  async waitForTerminalStatus(jobId: string): Promise<JobRecord> {
-    while (true) {
-      const job = await this.queue.getJob(jobId);
-      if (!job) throw new Error(`Job not found: ${jobId}`);
+  waitForTerminalStatus(jobId: string): Promise<JobRecord> {
+    const terminal = new Set([JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.CANCELED]);
 
-      if ([JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.CANCELED].includes(job.status)) {
-        return job;
-      }
-      await new Promise((r) => setTimeout(r, 100));
-    }
+    return new Promise((resolve, reject) => {
+      let settled = false;
+
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        unsub();
+        fn();
+      };
+
+      const unsub = this.hub.subscribe(jobId, (evt) => {
+        if (evt.event_type === "STATUS" && terminal.has(evt.payload.status)) {
+          settle(() => {
+            this.queue.getJob(jobId)
+              .then((job) => job ? resolve(job) : reject(new Error(`Job not found: ${jobId}`)))
+              .catch(reject);
+          });
+        }
+      });
+
+      // Resolve immediately if the job already reached a terminal state before we subscribed.
+      this.queue.getJob(jobId)
+        .then((job) => {
+          if (!job) { settle(() => reject(new Error(`Job not found: ${jobId}`))); return; }
+          if (terminal.has(job.status)) { settle(() => resolve(job)); }
+        })
+        .catch((err) => settle(() => reject(err)));
+    });
   }
 }
 

--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -228,7 +228,9 @@ export class ElevateCore {
   }
 
   async health(): Promise<HealthResponse> {
-    return { ok: true, ollama_url: vscode.workspace.getConfiguration("elevate").get("ollamaUrl") ?? "http://localhost:11434" };
+    const ollamaUrl = vscode.workspace.getConfiguration("elevate").get("ollamaUrl") as string ?? "http://localhost:11434";
+    const ok = await this.checkOllama();
+    return { ok, ollama_url: ollamaUrl };
   }
 
   async checkOllama(): Promise<boolean> {

--- a/elevate/src/backend/JobQueue.ts
+++ b/elevate/src/backend/JobQueue.ts
@@ -109,7 +109,7 @@ export class JobQueue {
     }
   }
 
-    const job_id = String(Date.now()) + String(Math.floor(Math.random() * 10000)).padStart(4, "0");
+    const job_id = randomUUID();
 
     
     const now = isoNow();

--- a/elevate/src/backend/JobStore.ts
+++ b/elevate/src/backend/JobStore.ts
@@ -41,8 +41,18 @@ export class JobStore {
     const idx = jobs.findIndex((j) => j.job_id === job.job_id);
     if (idx >= 0) jobs[idx] = job;
     else jobs.unshift(job);
-    // keep last 200
+    // keep last 200, delete text files for pruned jobs
+    const pruned = jobs.slice(200);
     await this.saveAll(jobs.slice(0, 200));
+    await Promise.all(pruned.map((j) => this.deleteResultText(j.job_id)));
+  }
+
+  private async deleteResultText(jobId: string): Promise<void> {
+    try {
+      await vscode.workspace.fs.delete(this.jobTextUri(jobId));
+    } catch {
+      // file may not exist, ignore
+    }
   }
 
   async setResultText(jobId: string, text: string): Promise<void> {

--- a/elevate/src/backend/OllamaClient.ts
+++ b/elevate/src/backend/OllamaClient.ts
@@ -59,7 +59,13 @@ export class OllamaClient {
         buffer = buffer.slice(idx + 1);
         if (!line) continue;
 
-        const raw = JSON.parse(line);
+        let raw: any;
+        try {
+          raw = JSON.parse(line);
+        } catch {
+          console.warn(`[OllamaClient] Skipping malformed NDJSON line: ${line}`);
+          continue;
+        }
         const delta = raw?.message?.content ?? "";
         yield { delta, raw };
 

--- a/elevate/src/backend/SSEHub.ts
+++ b/elevate/src/backend/SSEHub.ts
@@ -2,11 +2,17 @@ import { JobEvent } from "./types";
 
 type Listener = (evt: JobEvent) => void;
 
+const MAX_HISTORY_JOBS = 200;
+
 export class SseHub {
   private listeners = new Map<string, Set<Listener>>();
   private history = new Map<string, JobEvent[]>(); // small in-memory ring per job
 
   emit(evt: JobEvent) {
+    if (!this.history.has(evt.job_id) && this.history.size >= MAX_HISTORY_JOBS) {
+      const oldest = this.history.keys().next().value as string;
+      this.history.delete(oldest);
+    }
     const arr = this.history.get(evt.job_id) ?? [];
     arr.push(evt);
     // keep last 500 events
@@ -28,6 +34,11 @@ export class SseHub {
       s.delete(fn);
       if (s.size === 0) this.listeners.delete(jobId);
     };
+  }
+
+  prune(jobId: string): void {
+    this.history.delete(jobId);
+    this.listeners.delete(jobId);
   }
 
   getHistory(jobId: string, afterIndex: number): JobEvent[] {

--- a/elevate/src/backend/SessionContext.ts
+++ b/elevate/src/backend/SessionContext.ts
@@ -31,6 +31,10 @@ export class SessionContext {
         return this.recentFeedback;
     }
 
+    public restoreFeedback(feedback: Feedback[]): void {
+        this.recentFeedback = [...feedback];
+    }
+
     public clearFeedback(): void {
         this.recentFeedback = [];
     }

--- a/elevate/src/backend/SessionContext.ts
+++ b/elevate/src/backend/SessionContext.ts
@@ -7,6 +7,8 @@ export interface Feedback {
     response: string;
 }
 
+const MAX_FEEDBACK = 50;
+
 export class SessionContext {
     private activeFile?: FileSnapshot;
     private recentFeedback: Feedback[] = [];
@@ -25,6 +27,9 @@ export class SessionContext {
             filePath: this.activeFile?.uri ?? 'unknown',
             response
         });
+        if (this.recentFeedback.length > MAX_FEEDBACK) {
+            this.recentFeedback.shift();
+        }
     }
 
     public getRecentFeedback(): Feedback[] {

--- a/elevate/src/backend/StorageLayer.ts
+++ b/elevate/src/backend/StorageLayer.ts
@@ -1,66 +1,30 @@
 import * as vscode from "vscode";
+import { Feedback } from "./SessionContext";
+import { FileSnapshot } from "./FileSnapshot";
 
-// Final JSON structure (what gets stored)
-export interface Settings {
-  theme: "light" | "dark";
-  notificationsEnabled: boolean;
-  language: string;
+export interface ElevatePersistedState {
+  recentFeedback: Feedback[];
+  lastActiveFile?: FileSnapshot;
 }
 
-// Raw input (from IO layer, can be messy or partial)
-export type RawSettings = Partial<{
-  theme: unknown;
-  notificationsEnabled: unknown;
-  language: unknown;
-}>;
+const STATE_KEY = "elevate.state";
+const MAX_FEEDBACK = 50;
 
-// Default values
-const DEFAULT_SETTINGS: Settings = {
-  theme: "light",
-  notificationsEnabled: true,
-  language: "en",
-};
-
-const SETTINGS_KEY = "myExtension.settings";
-
-// Main builder function
-export function buildSettings(input: RawSettings): Settings {
-  return {
-    theme: normalizeTheme(input.theme),
-    notificationsEnabled: normalizeBoolean(input.notificationsEnabled),
-    language: normalizeLanguage(input.language),
-  };
-}
-
-// --- Storage functions ---
-export async function saveSettings (
+export function saveElevateState(
   context: vscode.ExtensionContext,
-  settings: Settings
-): Promise<void>{
-  await context.globalState.update(SETTINGS_KEY, settings);
+  state: ElevatePersistedState
+): void {
+  const capped: ElevatePersistedState = {
+    ...state,
+    recentFeedback: state.recentFeedback.slice(-MAX_FEEDBACK),
+  };
+  void context.globalState.update(STATE_KEY, capped);
 }
 
-export function loadSettings (
+export function loadElevateState(
   context: vscode.ExtensionContext
-): Settings {
-  const raw = context.globalState.get<RawSettings>(SETTINGS_KEY, {});
-  return buildSettings(raw);
-  }
-
-// --- Helper functions ---
-
-function normalizeTheme(value: unknown): "light" | "dark" {
-  return value === "dark" ? "dark" : DEFAULT_SETTINGS.theme;
-}
-
-function normalizeBoolean(value: unknown): boolean {
-  if (typeof value === "boolean") { return value; }
-  if (typeof value === "string") { return value.toLowerCase() === "true"; }
-  return DEFAULT_SETTINGS.notificationsEnabled;
-}
-
-function normalizeLanguage(value: unknown): string {
-  return typeof value === "string" && value.length > 0
-    ? value
-    : DEFAULT_SETTINGS.language;
+): ElevatePersistedState {
+  return context.globalState.get<ElevatePersistedState>(STATE_KEY, {
+    recentFeedback: [],
+  });
 }

--- a/elevate/src/extension.ts
+++ b/elevate/src/extension.ts
@@ -61,6 +61,7 @@ export async function activate(context: vscode.ExtensionContext) {
       stateManager.getSession().setActiveFile(result.snapshot);
     }
     stateManager.getSession().addFeedback(result.modelResponse);
+    stateManager.saveState(result.ctx);
   });
 
   context.subscriptions.push(

--- a/elevate/src/extension.ts
+++ b/elevate/src/extension.ts
@@ -69,11 +69,6 @@ export async function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  // Next sprint: diagnostics — parses the model response and pushes inline squiggles to the editor.
-  controller.onAnalysisComplete((_result) => {
-    // TODO next sprint: diagnosticsProvider.set(_result.uri, _result.modelResponse);
-  });
-
   const cfg = vscode.workspace.getConfiguration("elevate");
 
   const cursorEnabled = cfg.get<boolean>("cursorTracking.enabled", true);

--- a/elevate/src/extension.ts
+++ b/elevate/src/extension.ts
@@ -4,7 +4,7 @@ import { JobEvent, JobRecord, JobStatus } from "./backend/types";
 import { CursorTracker } from "./extension/cursorTracker";
 import { Logger } from "./util/Logger";
 import { ExtensionController } from "./extension/ExtensionController";
-import { loadSettings } from "./backend/StorageLayer";
+import { loadElevateState, saveElevateState } from "./backend/StorageLayer";
 import { CoreStateManager } from "./backend/CoreStateManager";
 
 let backend: ElevateCore | undefined;
@@ -18,9 +18,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   backend = new ElevateCore(context, output);
 
-  // Load persisted settings on activation
-  const settings = loadSettings(context);
-  output.appendLine("[ELEVATE Loaded Settings: " + JSON.stringify(settings));
+  // Restore persisted state from previous session
+  const persistedState = loadElevateState(context);
+  output.appendLine(`[ELEVATE] Restored ${persistedState.recentFeedback.length} feedback entries from previous session.`);
 
   // Start backend on activation, but don't crash activation if it fails.
   try {
@@ -48,6 +48,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const stateManager = new CoreStateManager();
   stateManager.initialize();
+  stateManager.getSession().restoreFeedback(persistedState.recentFeedback);
+  if (persistedState.lastActiveFile) {
+    stateManager.getSession().setActiveFile(persistedState.lastActiveFile);
+  }
 
   const controller = new ExtensionController(backend, logger);
   controller.activateStatusBar(context);
@@ -62,6 +66,10 @@ export async function activate(context: vscode.ExtensionContext) {
     }
     stateManager.getSession().addFeedback(result.modelResponse);
     stateManager.saveState(result.ctx);
+    saveElevateState(context, {
+      recentFeedback: stateManager.getSession().getRecentFeedback(),
+      lastActiveFile: stateManager.getSession().getActiveFile(),
+    });
   });
 
   context.subscriptions.push(

--- a/elevate/src/extension/ExtensionController.ts
+++ b/elevate/src/extension/ExtensionController.ts
@@ -68,23 +68,24 @@ export class ExtensionController implements vscode.Disposable {
         const openFileListener = vscode.workspace.onDidOpenTextDocument(
             async (document: vscode.TextDocument) => {
                 this.logger.info(`[open-file] fired: scheme=${document.uri.scheme} uri=${document.uri.toString()}`);
-                if (document.uri.scheme !== 'file') return;
+                if (document.uri.scheme !== 'file') { return; }
+                if (document.languageId !== 'python') { return; }
 
                 this.logger.info(`[analysis] started for: ${document.uri.toString()}`);
-                if (this.statusBar) this.statusBar.text ='$(sync~spin) Elevate: Analyzing...';
+                if (this.statusBar) { this.statusBar.text = '$(sync~spin) Elevate: Analyzing...'; }
                 const ctx = new ElevateContext(document);
                 ctx.cursorLine = vscode.window.activeTextEditor?.selection.active.line;
 
                 try {
                     await this.backend.runPipeline(ctx);
                 } catch (err: any) {
-                    if (this.statusBar) this.statusBar.text ='$(error) Elevate: Failed';
+                    if (this.statusBar) { this.statusBar.text = '$(error) Elevate: Failed'; }
                     this.logger.error(`[analysis] pipeline error: ${err?.message ?? String(err)}`);
                     return;
                 }
 
                 if (ctx.modelResponse && ctx.analysisResult) {
-                    if (this.statusBar) this.statusBar.text = '$(check) Elevate: Done';
+                    if (this.statusBar) { this.statusBar.text = '$(check) Elevate: Done'; }
                     this.logger.logResponseFinal(ctx.modelResponse);
                     this.handleAnalysisComplete({
                         uri: ctx.snapshot?.uri ?? document.uri.toString(),
@@ -92,10 +93,10 @@ export class ExtensionController implements vscode.Disposable {
                         snapshot: ctx.snapshot,
                     });
                 } else if (ctx.modelResponse && !ctx.analysisResult) {
-                    if (this.statusBar) this.statusBar.text = '$(warning) Elevate: Could not parse response';
+                    if (this.statusBar) { this.statusBar.text = '$(warning) Elevate: Could not parse response'; }
                     this.logger.info('[analysis] response was not valid JSON after retry.');
                 } else {
-                    if (this.statusBar) this.statusBar.text = '$(circle-outline) Elevate: Idle';
+                    if (this.statusBar) { this.statusBar.text = '$(circle-outline) Elevate: Idle'; }
                     this.logger.info('[analysis] pipeline completed with no model response.');
                 }
             }
@@ -115,6 +116,7 @@ export class ExtensionController implements vscode.Disposable {
             fsWatcherEnabled: options.fsWatcherEnabled ?? false,
             fsWatcherGlob: options.fsWatcherGlob,
             onEdit: async (doc) => {
+                if (doc.languageId !== 'python') { return; }
                 this.logger.info(`[analysis] started on save: ${doc.uri.toString()} (version=${doc.version})`);
                 if (this.statusBar) this.statusBar.text ='$(sync~spin) Elevate: Analyzing...';
                 const ctx = new ElevateContext(doc);

--- a/elevate/src/extension/ExtensionController.ts
+++ b/elevate/src/extension/ExtensionController.ts
@@ -11,6 +11,7 @@ export interface AnalysisResult {
     uri: string;           // file that was analysed
     modelResponse: string; // text returned by Ollama
     snapshot?: FileSnapshot;
+    ctx: ElevateContext;
 }
 
 // ExtensionController is the communication layer between VSCode events (file open, save)
@@ -91,6 +92,7 @@ export class ExtensionController implements vscode.Disposable {
                         uri: ctx.snapshot?.uri ?? document.uri.toString(),
                         modelResponse: ctx.modelResponse,
                         snapshot: ctx.snapshot,
+                        ctx,
                     });
                 } else if (ctx.modelResponse && !ctx.analysisResult) {
                     if (this.statusBar) { this.statusBar.text = '$(warning) Elevate: Could not parse response'; }
@@ -137,6 +139,7 @@ export class ExtensionController implements vscode.Disposable {
                         uri: ctx.snapshot?.uri ?? doc.uri.toString(),
                         modelResponse: ctx.modelResponse,
                         snapshot: ctx.snapshot,
+                        ctx,
                     });
                 } else if (ctx.modelResponse && !ctx.analysisResult) {
                     if (this.statusBar) this.statusBar.text = '$(warning) Elevate: Could not parse response';

--- a/elevate/src/extension/editListener.ts
+++ b/elevate/src/extension/editListener.ts
@@ -8,7 +8,7 @@ export interface EditListenerOptions {
   maxWaitMs?: number;
   fsWatcherEnabled: boolean;
   fsWatcherGlob?: string;
-  onEdit?: (doc: vscode.TextDocument) => void;
+  onEdit?: (doc: vscode.TextDocument) => Promise<void>;
 }
 
 export class EditListener implements vscode.Disposable {
@@ -71,7 +71,7 @@ export class EditListener implements vscode.Disposable {
     // Cancel any pending debounced edit — the save fires onEdit directly below
     this.debouncer.cancel(key);
 
-    this.opts.onEdit?.(doc);
+    this.opts.onEdit?.(doc).catch((err) => this.logger.error(`[save] onEdit error: ${err?.message ?? String(err)}`));
 
     this.logger.info(`[save] ${doc.uri.toString()} (version=${doc.version})`);
   }
@@ -98,6 +98,6 @@ export class EditListener implements vscode.Disposable {
 
     this.logger.info(`[edit] ${doc.uri.toString()} (version=${doc.version}, dirty=${doc.isDirty})`);
 
-    this.opts.onEdit?.(doc);
+    this.opts.onEdit?.(doc).catch((err) => this.logger.error(`[edit] onEdit error: ${err?.message ?? String(err)}`));
   }
 }

--- a/elevate/src/pipeline/Stage.ts
+++ b/elevate/src/pipeline/Stage.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { ElevateContext } from "../backend/ElevateContext";
 import { BlockEvent } from "../backend/parserTypes";
 import { spawn } from "child_process";
+import { randomUUID } from "crypto";
 import { writeFile, readFile, unlink } from "fs/promises";
 import * as os from "os";
 import * as path from "path";
@@ -34,8 +35,8 @@ export class ParseStage implements Stage {
 
         logger.debug(`ParseStage: parsing ${code.length} chars`);
 
-        const inputPath = path.join(os.tmpdir(), `elevate_in_${Date.now()}.py`);
-        const outputPath = path.join(os.tmpdir(), `elevate_out_${Date.now()}.json`);
+        const inputPath = path.join(os.tmpdir(), `elevate_in_${randomUUID()}.py`);
+        const outputPath = path.join(os.tmpdir(), `elevate_out_${randomUUID()}.json`);
 
         await writeFile(inputPath, code, "utf-8");
 
@@ -95,8 +96,8 @@ export class PromptBuilderStage implements Stage {
         const events = filterToActiveBlock(ctx.parsed, ctx.cursorLine);
         logger.debug(`PromptBuilderStage: building prompt from ${events.length}/${ctx.parsed.length} block event(s) (cursorLine=${ctx.cursorLine})`);
 
-        const inputPath = path.join(os.tmpdir(), `elevate_prompt_in_${Date.now()}.json`);
-        const outputPath = path.join(os.tmpdir(), `elevate_prompt_out_${Date.now()}.txt`);
+        const inputPath = path.join(os.tmpdir(), `elevate_prompt_in_${randomUUID()}.json`);
+        const outputPath = path.join(os.tmpdir(), `elevate_prompt_out_${randomUUID()}.txt`);
 
         await writeFile(inputPath, JSON.stringify(events), "utf-8");
 

--- a/elevate/src/pipeline/Stage.ts
+++ b/elevate/src/pipeline/Stage.ts
@@ -15,13 +15,6 @@ export interface Stage {
     run(ctx: ElevateContext, logger: Logger): Promise<void>;
 }
 
-export class SanitizationStage implements Stage {
-    name = "Sanitization Stage";
-    async run(_ctx: ElevateContext, _logger: Logger): Promise<void> {
-
-    }
-}
-
 export class ParseStage implements Stage {
     name = "Parse Stage";
 

--- a/elevate/src/test/Pipeline.test.ts
+++ b/elevate/src/test/Pipeline.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { ElevateContext } from '../backend/ElevateContext';
 import { Pipeline } from '../pipeline/Pipeline';
-import { Stage, SanitizationStage } from '../pipeline/Stage';
+import { Stage } from '../pipeline/Stage';
 import { Logger } from '../util/Logger';
 
 suite('Pipeline', () => {
@@ -37,13 +37,6 @@ suite('Pipeline', () => {
 
         await assert.rejects(() => pipeline.execute(ctx), /stage failed/);
         assert.deepStrictEqual(ran, ['good']);
-    });
-
-    test('runs without throwing on SanitizationStage alone', async () => {
-        const ctx = new ElevateContext('test context');
-        const logger = new Logger('test', false);
-        const pipeline = new Pipeline([new SanitizationStage()], logger);
-        await assert.doesNotReject(() => pipeline.execute(ctx));
     });
 
     test('executes successfully with empty stage list', async () => {

--- a/elevate/tsconfig.json
+++ b/elevate/tsconfig.json
@@ -6,7 +6,7 @@
 			"ES2022",
 			"dom"
 		],
-		"types": ["node"],
+		"types": ["node", "mocha"],
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,   /* enable all strict type-checking options */

--- a/elevate/tsconfig.json
+++ b/elevate/tsconfig.json
@@ -3,8 +3,10 @@
 		"module": "Node16",
 		"target": "ES2022",
 		"lib": [
-			"ES2022"
+			"ES2022",
+			"dom"
 		],
+		"types": ["node"],
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,   /* enable all strict type-checking options */


### PR DESCRIPTION
## Summary

- **Bugs fixed**: malformed NDJSON no longer crashes `chatStream`; `health()` now performs a real Ollama reachability check
- **Dead code removed**: empty `SanitizationStage`, dead `onAnalysisComplete` stub; `StorageLayer.ts` repurposed for real ELEVATE persistent state (`recentFeedback` + `lastActiveFile` saved/restored across sessions)
- **State wired up**: `CoreStateManager.saveState()` now called after every successful analysis via `AnalysisResult.ctx`
- **Memory/resource leaks fixed**: `recentFeedback` capped at 50; `SseHub` history evicts oldest job beyond 200; `JobStore` deletes `job_<id>.txt` files when jobs are pruned
- **Polish**: `waitForTerminalStatus` replaced busy-poll (100ms loop) with SSE hub subscription
- **tsconfig**: added `dom` and `node` to lib/types to resolve pre-existing type errors for `fetch`, `TextDecoder`, `path`, `console`, `suite`/`test`

## Test plan

- [ ] Open a Python file — analysis runs, response panel updates, no errors in Output: ELEVATE
- [ ] Reload VS Code — confirm feedback count is restored from previous session (check Output: ELEVATE log)
- [ ] Stop Ollama, run `ELEVATE: Backend Status` — should show NOT RUNNING instead of OK
- [ ] Run `ELEVATE: Run Prompt` — confirm streaming output works end to end
- [ ] Verify no TypeScript errors in Problems panel