### PR TITLE
fix: route all file analysis through the job queue

### DIFF
--- a/elevate/src/backend/ElevateContext.ts
+++ b/elevate/src/backend/ElevateContext.ts
@@ -36,6 +36,9 @@ export class ElevateContext {
     // compiler error/warnings
     diagnostics?: vscode.Diagnostic[];
 
+    // Raw metrics from Ollama's final response chunk (eval_count, eval_duration, etc.)
+    ollamaMetrics?: any;
+
     constructor(doc: vscode.TextDocument);
 
     /** TEST ONLY: construct from raw text for unit tests */

--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -33,7 +33,6 @@ export class ElevateCore {
     const concurrency = cfg.get<number>("concurrency") ?? 1;
 
     this.ollama = new OllamaClient(ollamaUrl);
-    this.queue = new JobQueue(this.store, this.hub, this.ollama, { concurrency });
 
     const parserBin = path.join(context.extensionUri.fsPath, "cpp_native", "build", "bin", "parser");
     const promptBuilderBin = path.join(context.extensionUri.fsPath, "cpp_native", "build", "bin", "prompt_builder");
@@ -47,6 +46,18 @@ export class ElevateCore {
       ],
       this.logger
     );
+
+    this.queue = new JobQueue(this.store, this.hub, this.ollama, { concurrency }, async (payload, _signal) => {
+      const ctx = new ElevateContext(payload.fileText);
+      ctx.analysisTarget = payload.fileText;
+      ctx.cursorLine = payload.cursorLine;
+      await this.pipeline.execute(ctx);
+      return {
+        modelResponse: ctx.modelResponse ?? "",
+        analysisResult: ctx.analysisResult,
+        ollamaMetrics: ctx.ollamaMetrics,
+      };
+    });
 
     this.diagnosticCollection = vscode.languages.createDiagnosticCollection("elevate");
 
@@ -176,6 +187,59 @@ export class ElevateCore {
       });
     });
 
+    router.add("GET", "/v1/stats", async (_req, res) => {
+      const all = await this.store.loadAll();
+      const done = all.filter(j => j.status === "succeeded" && j.started_at && j.finished_at);
+
+      const percentile = (arr: number[], p: number) => {
+        if (!arr.length) return null;
+        const sorted = [...arr].sort((a, b) => a - b);
+        const idx = Math.max(0, Math.ceil((p / 100) * sorted.length) - 1);
+        return Math.round(sorted[idx]);
+      };
+
+      const queueWaits = done.map(j => new Date(j.started_at!).getTime() - new Date(j.created_at).getTime());
+      const totalDurations = done.map(j => new Date(j.finished_at!).getTime() - new Date(j.started_at!).getTime());
+      const inferenceMs = done.filter(j => j.metrics?.eval_duration).map(j => Math.round(j.metrics!.eval_duration / 1e6));
+      const tokensPerSec = done.filter(j => j.metrics?.eval_count && j.metrics?.eval_duration).map(j => Math.round(j.metrics!.eval_count / (j.metrics!.eval_duration / 1e9)));
+      const promptTokens = done.filter(j => j.metrics?.prompt_eval_count).map(j => j.metrics!.prompt_eval_count as number);
+      const completionTokens = done.filter(j => j.metrics?.eval_count).map(j => j.metrics!.eval_count as number);
+
+      const agg = (arr: number[]) => arr.length === 0 ? null : {
+        count: arr.length,
+        avg: Math.round(arr.reduce((s, v) => s + v, 0) / arr.length),
+        min: Math.min(...arr),
+        max: Math.max(...arr),
+        p50: percentile(arr, 50),
+        p95: percentile(arr, 95),
+      };
+
+      const jobs = done.map(j => ({
+        job_id: j.job_id,
+        model: j.model,
+        queue_wait_ms: new Date(j.started_at!).getTime() - new Date(j.created_at).getTime(),
+        total_duration_ms: new Date(j.finished_at!).getTime() - new Date(j.started_at!).getTime(),
+        inference_ms: j.metrics?.eval_duration ? Math.round(j.metrics.eval_duration / 1e6) : null,
+        prompt_tokens: j.metrics?.prompt_eval_count ?? null,
+        completion_tokens: j.metrics?.eval_count ?? null,
+        tokens_per_sec: (j.metrics?.eval_count && j.metrics?.eval_duration) ? Math.round(j.metrics.eval_count / (j.metrics.eval_duration / 1e9)) : null,
+      }));
+
+      HttpServer.json(res, 200, {
+        total_jobs: all.length,
+        succeeded_jobs: done.length,
+        canceled_jobs: all.filter(j => j.status === "canceled").length,
+        failed_jobs: all.filter(j => j.status === "failed").length,
+        queue_wait_ms: agg(queueWaits),
+        total_duration_ms: agg(totalDurations),
+        inference_ms: agg(inferenceMs),
+        tokens_per_sec: agg(tokensPerSec),
+        total_prompt_tokens: promptTokens.reduce((s, v) => s + v, 0),
+        total_completion_tokens: completionTokens.reduce((s, v) => s + v, 0),
+        jobs,
+      });
+    });
+
     // SSE events: /v1/jobs/:id/events?after=0
     router.add("GET", "/v1/jobs/:id/events", async (req, res, ctx) => {
       const jobId = ctx.params.id;
@@ -258,11 +322,33 @@ export class ElevateCore {
   }
 
   async runPipeline(ctx: ElevateContext): Promise<void> {
-    await this.pipeline.execute(ctx);
+    const fileText = ctx.analysisTarget ?? ctx.snapshot?.text ?? ctx.text ?? "";
+    const fileUri = ctx.snapshot?.uri ?? "";
+    const version = ctx.snapshot?.version ?? ctx.version ?? 0;
 
-    if (!ctx.snapshot?.uri) return;
+    const job = await this.queue.enqueuePipelineJob({
+      fileText,
+      fileUri,
+      cursorLine: ctx.cursorLine,
+      version,
+      priority: 5,
+    });
 
-    const uri = vscode.Uri.parse(ctx.snapshot.uri);
+    const done = await this.waitForTerminalStatus(job.job_id);
+
+    if (done.status === JobStatus.FAILED) {
+      throw new Error(done.error ?? "Pipeline job failed");
+    }
+
+    if (done.status === JobStatus.SUCCEEDED) {
+      ctx.modelResponse = done.result_text ?? undefined;
+      ctx.analysisResult = done.analysis_result ?? undefined;
+      ctx.ollamaMetrics = done.metrics ?? undefined;
+    }
+
+    if (!fileUri) { return; }
+
+    const uri = vscode.Uri.parse(fileUri);
     const diagnostics = ctx.analysisResult
       ? ctx.analysisResult.issues.map(issue => new vscode.Diagnostic(
           new vscode.Range(issue.line - 1, 0, issue.line - 1, Number.MAX_SAFE_INTEGER),

--- a/elevate/src/backend/JobQueue.ts
+++ b/elevate/src/backend/JobQueue.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { JobRecord, JobStatus, JobEvent, ChatMessage } from "./types";
+import { JobRecord, JobStatus, JobEvent, ChatMessage, ModelAnalysisResult } from "./types";
 import { isoNow } from "../util/time";
 import { JobStore } from "./JobStore";
 import { SseHub } from "./SSEHub";
@@ -8,6 +8,20 @@ import { OllamaClient } from "./OllamaClient";
 export interface QueueConfig {
   concurrency: number; // 1..4
 }
+
+export interface PipelineJobPayload {
+  fileText: string;
+  fileUri: string;
+  cursorLine?: number;
+}
+
+export interface PipelineJobResult {
+  modelResponse: string;
+  analysisResult?: ModelAnalysisResult | null;
+  ollamaMetrics?: any;
+}
+
+export type PipelineExecutor = (payload: PipelineJobPayload, signal: AbortSignal) => Promise<PipelineJobResult>;
 
 type Enqueued = {
   jobId: string;
@@ -28,7 +42,8 @@ export class JobQueue {
     private readonly store: JobStore,
     private readonly hub: SseHub,
     private readonly ollama: OllamaClient,
-    private readonly cfg: QueueConfig
+    private readonly cfg: QueueConfig,
+    private readonly pipelineExecutor?: PipelineExecutor,
   ) {}
 
   setFileVersion(key: string, version: number) {
@@ -145,6 +160,48 @@ export class JobQueue {
     return job;
   }
 
+  async enqueuePipelineJob(args: {
+    fileText: string;
+    fileUri: string;
+    cursorLine?: number;
+    version?: number;
+    priority?: number;
+  }): Promise<JobRecord> {
+    const analysis_key = args.fileUri;
+
+    const existingJobId = this.activeByKey.get(analysis_key);
+    if (existingJobId) {
+      await this.cancelJob(existingJobId);
+    }
+
+    const job_id = randomUUID();
+    const now = isoNow();
+    const job: JobRecord = {
+      job_id,
+      type: "PIPELINE_ANALYSIS",
+      priority: Math.max(0, Math.min(9, args.priority ?? 5)),
+      model: "pipeline",
+      status: JobStatus.QUEUED,
+      version: args.version ?? 0,
+      created_at: now,
+      updated_at: now,
+      started_at: null,
+      finished_at: null,
+      payload: { fileText: args.fileText, fileUri: args.fileUri, cursorLine: args.cursorLine, analysis_key },
+      result_text: null,
+      error: null,
+      metrics: null,
+      analysis_result: null,
+    };
+
+    await this.setJob(job);
+    this.activeByKey.set(analysis_key, job_id);
+    this.queue.push({ jobId: job_id, priority: job.priority, enqueuedAt: Date.now() });
+    this.sortQueue();
+    this.emit(job_id, "STATUS", { status: JobStatus.QUEUED });
+    return job;
+  }
+
   async cancelJob(jobId: string): Promise<{ job_id: string; previous_status: JobStatus; new_status: JobStatus }> {
     const job = await this.getJob(jobId);
     if (!job) throw new Error(`Job not found: ${jobId}`);
@@ -223,65 +280,102 @@ export class JobQueue {
       this.controllers.set(job.job_id, controller);
 
       try {
-        let full = "";
-        let finalMetrics: any = null;
+        if (job.type === "PIPELINE_ANALYSIS") {
+          if (!this.pipelineExecutor) throw new Error("No pipeline executor registered");
 
-        const messages = job.payload?.messages ?? [];
-        for await (const part of this.ollama.chatStream({
-          model: job.model,
-          messages,
-          options: job.options ?? {},
-          keep_alive: job.keep_alive ?? "5m",
-          signal: controller.signal,
-        })) {
-        
-          const currentKey = job.payload?.analysis_key;
-          const currentVersion = currentKey ? this.fileVersions.get(currentKey) : undefined;
-          const versionStale = currentKey && currentVersion !== undefined && currentVersion !== job.version;
-          const keyStale = currentKey && this.activeByKey.get(currentKey) !== job.job_id;
+          const result = await this.pipelineExecutor(
+            {
+              fileText: job.payload?.fileText ?? "",
+              fileUri: job.payload?.fileUri ?? "",
+              cursorLine: job.payload?.cursorLine,
+            },
+            controller.signal
+          );
 
-          if (versionStale || keyStale) {
-            controller.abort();
-            throw new Error("stale_job");
+          const refreshed = await this.getJob(job.job_id);
+          if (refreshed?.status === JobStatus.CANCEL_REQUESTED || controller.signal.aborted) {
+            job.status = JobStatus.CANCELED;
+            job.updated_at = isoNow();
+            job.finished_at = isoNow();
+            await this.setJob(job);
+            this.emit(job.job_id, "STATUS", { status: JobStatus.CANCELED });
+            continue;
           }
 
-          if (controller.signal.aborted) throw new Error("aborted");
-
-          const delta = part.delta ?? "";
-          if (delta) {
-            full += delta;
-            this.emit(job.job_id, "OUTPUT_CHUNK", { delta });
-          }
-          if (part.raw?.done) {
-            finalMetrics = part.raw;
-            break;
-          }
-        }
-
-        // if cancel requested, mark canceled even if stream ended
-        const refreshed = await this.getJob(job.job_id);
-        const wasCancelRequested = refreshed?.status === JobStatus.CANCEL_REQUESTED;
-
-        if (wasCancelRequested || controller.signal.aborted) {
-          job.status = JobStatus.CANCELED;
+          job.status = JobStatus.SUCCEEDED;
           job.updated_at = isoNow();
           job.finished_at = isoNow();
+          job.result_text = result.modelResponse;
+          job.metrics = result.ollamaMetrics ?? null;
+          job.analysis_result = result.analysisResult ?? null;
+
+          await this.store.setResultText(job.job_id, result.modelResponse);
           await this.setJob(job);
-          this.emit(job.job_id, "STATUS", { status: JobStatus.CANCELED });
-          continue;
+
+          this.emit(job.job_id, "METRIC", { metrics: job.metrics });
+          this.emit(job.job_id, "STATUS", { status: JobStatus.SUCCEEDED });
+
+        } else {
+          let full = "";
+          let finalMetrics: any = null;
+
+          const messages = job.payload?.messages ?? [];
+          for await (const part of this.ollama.chatStream({
+            model: job.model,
+            messages,
+            options: job.options ?? {},
+            keep_alive: job.keep_alive ?? "5m",
+            signal: controller.signal,
+          })) {
+
+            const currentKey = job.payload?.analysis_key;
+            const currentVersion = currentKey ? this.fileVersions.get(currentKey) : undefined;
+            const versionStale = currentKey && currentVersion !== undefined && currentVersion !== job.version;
+            const keyStale = currentKey && this.activeByKey.get(currentKey) !== job.job_id;
+
+            if (versionStale || keyStale) {
+              controller.abort();
+              throw new Error("stale_job");
+            }
+
+            if (controller.signal.aborted) throw new Error("aborted");
+
+            const delta = part.delta ?? "";
+            if (delta) {
+              full += delta;
+              this.emit(job.job_id, "OUTPUT_CHUNK", { delta });
+            }
+            if (part.raw?.done) {
+              finalMetrics = part.raw;
+              break;
+            }
+          }
+
+          // if cancel requested, mark canceled even if stream ended
+          const refreshed = await this.getJob(job.job_id);
+          const wasCancelRequested = refreshed?.status === JobStatus.CANCEL_REQUESTED;
+
+          if (wasCancelRequested || controller.signal.aborted) {
+            job.status = JobStatus.CANCELED;
+            job.updated_at = isoNow();
+            job.finished_at = isoNow();
+            await this.setJob(job);
+            this.emit(job.job_id, "STATUS", { status: JobStatus.CANCELED });
+            continue;
+          }
+
+          job.status = JobStatus.SUCCEEDED;
+          job.updated_at = isoNow();
+          job.finished_at = isoNow();
+          job.result_text = full;
+          job.metrics = finalMetrics ?? null;
+
+          await this.store.setResultText(job.job_id, full);
+          await this.setJob(job);
+
+          this.emit(job.job_id, "METRIC", { metrics: job.metrics });
+          this.emit(job.job_id, "STATUS", { status: JobStatus.SUCCEEDED });
         }
-
-        job.status = JobStatus.SUCCEEDED;
-        job.updated_at = isoNow();
-        job.finished_at = isoNow();
-        job.result_text = full;
-        job.metrics = finalMetrics ?? null;
-
-        await this.store.setResultText(job.job_id, full);
-        await this.setJob(job);
-
-        this.emit(job.job_id, "METRIC", { metrics: job.metrics });
-        this.emit(job.job_id, "STATUS", { status: JobStatus.SUCCEEDED });
       } catch (err: any) {
         const refreshed = await this.getJob(job.job_id);
         const canceling = refreshed?.status === JobStatus.CANCEL_REQUESTED || controller.signal.aborted;

--- a/elevate/src/backend/types.ts
+++ b/elevate/src/backend/types.ts
@@ -1,4 +1,4 @@
-export type JobType = "OLLAMA_CHAT" | "OLLAMA_GENERATE";
+export type JobType = "OLLAMA_CHAT" | "OLLAMA_GENERATE" | "PIPELINE_ANALYSIS";
 
 export enum JobStatus {
   QUEUED = "queued",
@@ -50,6 +50,7 @@ export interface JobRecord {
   result_text?: string | null;
   error?: string | null;
   metrics?: Record<string, any> | null;
+  analysis_result?: ModelAnalysisResult | null;
 }
 
 export type JobEventType = "STATUS" | "OUTPUT_CHUNK" | "ERROR" | "METRIC";

--- a/elevate/src/extension/ResponsePanel.ts
+++ b/elevate/src/extension/ResponsePanel.ts
@@ -49,7 +49,10 @@ export class ResponsePanel implements vscode.Disposable {
 
     private parseResponse(raw: string): AnalysisResponse | null {
         try {
-            const parsed = JSON.parse(raw);
+            const start = raw.indexOf('{');
+            const end = raw.lastIndexOf('}');
+            if (start === -1 || end === -1 || end < start) return null;
+            const parsed = JSON.parse(raw.slice(start, end + 1));
             if (
                 typeof parsed.structural_summary === 'string' &&
                 Array.isArray(parsed.issues) &&

--- a/elevate/src/pipeline/Stage.ts
+++ b/elevate/src/pipeline/Stage.ts
@@ -232,8 +232,9 @@ export class OllamaStage implements Stage {
 
         logger.info(`OllamaStage: sending prompt to model "${model}"`);
 
-        const response = await this.streamResponse(ctx.prompt, model);
+        const { response, metrics } = await this.streamResponse(ctx.prompt, model);
         ctx.modelResponse = response;
+        ctx.ollamaMetrics = metrics;
         ctx.analysisResult = parseModelResponse(response);
 
         if (ctx.analysisResult) {
@@ -254,8 +255,9 @@ export class OllamaStage implements Stage {
             },
         ];
 
-        const retryResponse = await this.streamResponse(correctionMessages, model);
+        const { response: retryResponse, metrics: retryMetrics } = await this.streamResponse(correctionMessages, model);
         ctx.modelResponse = retryResponse;
+        ctx.ollamaMetrics = retryMetrics;
         ctx.analysisResult = parseModelResponse(retryResponse);
 
         if (ctx.analysisResult) {
@@ -265,16 +267,18 @@ export class OllamaStage implements Stage {
         }
     }
 
-    private async streamResponse(messages: import("../backend/types").ChatMessage[], model: string): Promise<string> {
+    private async streamResponse(messages: import("../backend/types").ChatMessage[], model: string): Promise<{ response: string; metrics: any | null }> {
         const abort = new AbortController();
         let response = "";
+        let metrics: any = null;
         for await (const chunk of this.client.chatStream({
             model,
             messages,
             signal: abort.signal,
         })) {
             if (chunk.delta) response += chunk.delta;
+            if (chunk.raw?.done) metrics = chunk.raw;
         }
-        return response;
+        return { response, metrics };
     }
 }


### PR DESCRIPTION
## Summary
- `ExtensionController` was calling `runPipeline()` directly, completely bypassing the job queue — meaning no analysis was ever persisted, cancellation/concurrency controls were unused, and `/v1/stats` returned empty results
- Added `PIPELINE_ANALYSIS` job type and `PipelineExecutor` callback to `JobQueue`, with a new `enqueuePipelineJob()` method
- Rewrote `ElevateCore.runPipeline()` to enqueue a pipeline job and await its terminal status, then write results back to the `ElevateContext`
- `OllamaStage` now captures Ollama response metrics (`eval_count`, `eval_duration`, etc.) and stores them on both the context and the `JobRecord`

## Test plan
- [ ] Open a Python file — analysis should complete normally (status bar, diagnostics, response panel unchanged)
- [ ] `curl http://127.0.0.1:34345/v1/jobs` should show PIPELINE_ANALYSIS jobs after opening files
- [ ] `curl http://127.0.0.1:34345/v1/stats` should return real timing/token data
- [ ] Opening a second version of the same file should cancel the previous job (stale job handling still works)