### PR TITLE
Fix merge conflict in ElevateCore and initialize ollamaProcess

### DIFF
--- a/elevate/src/backend/ElevateCore.ts
+++ b/elevate/src/backend/ElevateCore.ts
@@ -35,6 +35,7 @@ export class ElevateCore {
     const concurrency = cfg.get<number>("concurrency") ?? 1;
 
     this.ollama = new OllamaClient(ollamaUrl);
+    this.ollamaProcess = new OllamaProcess(ollamaUrl, output);
     const ext = process.platform === "win32" ? ".exe" : "";
     const root = context.extensionUri.fsPath;
     // Packaged extension: binaries are in bin/ at the extension root.
@@ -301,11 +302,8 @@ export class ElevateCore {
     this.queue.stop();
     void this.server?.close();
     this.server = null;
-<<<<<<< HEAD
     this.diagnosticCollection.dispose();
-=======
     this.ollamaProcess.stop();
->>>>>>> origin/main
   }
 
   async health(): Promise<HealthResponse> {


### PR DESCRIPTION
## Summary
- Resolved merge conflict in `ElevateCore.stop()` — kept both `diagnosticCollection.dispose()` and `ollamaProcess.stop()` since both are valid cleanup steps
- Added missing `this.ollamaProcess = new OllamaProcess(ollamaUrl, output)` initialization in the constructor, which was causing a TS2564 error

## Test plan
- [ ] Extension activates without errors
- [ ] `stop()` properly disposes the diagnostic collection and stops the Ollama process on deactivation