### PR TITLE
Marketplace prep: VSIX trim, publisher, cross-platform CI publish

### DIFF
--- a/elevate/.github/workflows/ci.yml
+++ b/elevate/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main, dev, backend]
+    tags: ['v*']
   pull_request:
     branches: [main, dev]
 
@@ -42,18 +43,28 @@ jobs:
 
   package:
     needs: test
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             target: linux-x64
+            ext: ''
           - os: macos-14
             target: darwin-arm64
+            ext: ''
           - os: macos-13
             target: darwin-x64
+            ext: ''
+          - os: windows-latest
+            target: win32-x64
+            ext: '.exe'
 
     runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - uses: actions/checkout@v4
@@ -74,13 +85,19 @@ jobs:
       - name: Build C++ binaries
         run: |
           cmake -S cpp_native -B cpp_native/build
-          cmake --build cpp_native/build
+          cmake --build cpp_native/build --config Release
 
       - name: Copy binaries to bin/
         run: |
           mkdir -p bin
-          cp cpp_native/build/bin/parser bin/
-          cp cpp_native/build/bin/prompt_builder bin/
+          # Windows MSVC drops binaries under bin/Release/; Unix puts them in bin/.
+          if [ -f "cpp_native/build/bin/Release/parser${{ matrix.ext }}" ]; then
+            cp "cpp_native/build/bin/Release/parser${{ matrix.ext }}" bin/
+            cp "cpp_native/build/bin/Release/prompt_builder${{ matrix.ext }}" bin/
+          else
+            cp "cpp_native/build/bin/parser${{ matrix.ext }}" bin/
+            cp "cpp_native/build/bin/prompt_builder${{ matrix.ext }}" bin/
+          fi
 
       - name: Install vsce
         run: npm install -g @vscode/vsce
@@ -93,3 +110,33 @@ jobs:
         with:
           name: elevate-${{ matrix.target }}
           path: "*.vsix"
+
+  publish:
+    needs: package
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Download all VSIX artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
+      - name: Publish each VSIX to the marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          for vsix in artifacts/*/*.vsix; do
+            echo "Publishing $vsix"
+            vsce publish --packagePath "$vsix" --no-dependencies
+          done

--- a/elevate/.vscodeignore
+++ b/elevate/.vscodeignore
@@ -5,11 +5,16 @@ node_modules/**
 src/**
 cpp_native/**
 scripts/**
+build/**
+test-files/**
+.github/**
+.husky/**
 .gitignore
 .yarnrc
-.husky/**
 esbuild.js
 vsc-extension-quickstart.md
+MARKETPLACE_TODO.md
+CONTRIBUTING.md
 **/tsconfig.json
 **/eslint.config.mjs
 **/*.map

--- a/elevate/package.json
+++ b/elevate/package.json
@@ -3,7 +3,7 @@
   "displayName": "ELEVATE",
   "description": "AI-powered Python code feedback using local LLMs via Ollama. No cloud, no API keys.",
   "version": "0.1.0",
-  "publisher": "PLACEHOLDER",
+  "publisher": "ElevenSeven",
   "icon": "images/icon.png",
   "galleryBanner": {
     "color": "#1e1e1e",


### PR DESCRIPTION
## Summary
- Set the marketplace publisher to **ElevenSeven** in `package.json`
- Trim `.vscodeignore` so the VSIX no longer ships `build/`, `test-files/`, `.github/`, `MARKETPLACE_TODO.md`, or `CONTRIBUTING.md` — local package went from 85 files / 150 KB → 10 files / 77 KB
- Add `windows-latest` (`win32-x64`) to the CI package matrix alongside Linux + macOS arm64/x64
- Add a tag-triggered `publish` job that downloads each platform's VSIX artifact and runs `vsce publish` using a `VSCE_PAT` secret

## Before this can publish
- [ ] Add `VSCE_PAT` secret in repo Settings → Secrets and variables → Actions (Azure DevOps PAT with Marketplace > Manage scope, scoped to All accessible organizations)
- [ ] Merge this PR
- [ ] Tag a release: `git tag v0.1.0 && git push --tags` to trigger publish

## Test plan
- [ ] `package` matrix succeeds on ubuntu-latest, macos-14, macos-13, windows-latest
- [ ] Each job uploads a VSIX artifact named `elevate-<target>`
- [ ] After tagging, `publish` downloads all four artifacts and pushes them to the marketplace
- [ ] Install the VSIX from the marketplace on each platform and verify `parser` + `prompt_builder` binaries resolve

## Caveats
- C++ code has not been verified to build on Windows MSVC. First push will surface any portability issues (likely missing `<cstdint>` / `<cstring>` headers if anything).
- `macos-13` runners are being deprecated by GitHub. If they go unavailable before publish, drop that matrix entry — Apple Silicon-only is acceptable for the marketplace.