### PR TITLE
Activate extension on VSCode startup

### DIFF
--- a/elevate/package.json
+++ b/elevate/package.json
@@ -24,6 +24,9 @@
     "Machine Learning"
   ],
   "main": "./dist/extension.js",
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION
## Summary
- Adds `activationEvents: ["onStartupFinished"]` to `package.json` so ELEVATE activates automatically once VSCode finishes loading.
- Without this, the extension stayed dormant on a fresh dev window — `activate()` only ran after the user invoked an `elevate.*` command, so the backend, cursor tracker, and edit listener never started on their own.
- `onStartupFinished` runs after the UI is ready, so it doesn't slow window startup.

## Test plan
- [ ] Launch the Extension Development Host on a clean window.
- [ ] Confirm the ELEVATE output channel logs `[ELEVATE] Activating...` and `[ELEVATE] Backend started.` without invoking any command first.
- [ ] Confirm the status bar item, edit listener, and cursor tracker are live immediately.