### PR TITLE
Drop darwin-x64 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,6 @@ jobs:
           - os: macos-14
             target: darwin-arm64
             ext: ''
-          - os: macos-13
-            target: darwin-x64
-            ext: ''
           - os: windows-latest
             target: win32-x64
             ext: '.exe'


### PR DESCRIPTION
## Summary
- Remove the `macos-13 / darwin-x64` entry from the package matrix. Intel Mac runners have been queuing for 15+ minutes and blocking publishes.
- Apple Silicon users continue to get the native `darwin-arm64` build; Intel Mac users will install that build via Rosetta. The Marketplace will list ELEVATE as compatible on darwin-arm64 only.

## Test plan
- [ ] CI on this PR runs `test` (Linux + macOS) — should pass quickly
- [ ] After merge, main `package` run produces 3 .vsix files (linux-x64, darwin-arm64, win32-x64) and finishes in well under 10 min
- [ ] Tagging `v0.1.0` triggers a successful publish